### PR TITLE
fix: group styling

### DIFF
--- a/docs/groups.md
+++ b/docs/groups.md
@@ -185,14 +185,17 @@ reference.
 
 ### Group chip colours
 
-Read-only group chips (profile menu) use a slate palette distinct from the
-brand-red program chips, so the two visibility dimensions read differently
-(`theme.ts::getGroupChipColors`):
+Groups now use the app's **secondary** palette as their shared visual identity
+(`theme.ts::getGroupChipColors`). The full-strength variant is used for primary
+group affordances (for example, the selected group in the Manage Groups list and
+the read-only group chips in the profile menu). The subtle variant is used for
+lower-emphasis inherited/read-only states in the category dialogs, and keeps
+text contrast at WCAG-AA without dimming the entire chip:
 
-| Mode | Background | Text | Contrast |
-|------|-----------|------|----------|
-| Light | `#5B6973` | `#FFFFFF` | ≈ 5.6:1 (WCAG-AA, normal text) |
-| Dark | `#8A99A6` | `#1E1E1E` | ≈ 5.5:1 (WCAG-AA, normal text) |
+| Mode | Full-strength background | Full-strength text | Subtle background | Subtle text |
+|------|--------------------------|--------------------|------------------|-------------|
+| Light | `#7F665D` | `#FFFFFF` | `rgba(127, 102, 93, 0.16)` | `#3E3C3A` |
+| Dark | `#A89288` | `#1E1E1E` | `rgba(168, 146, 136, 0.16)` | `#E0DDD9` |
 
 ## Export / import
 

--- a/frontend/src/components/AddCategoryDialog.tsx
+++ b/frontend/src/components/AddCategoryDialog.tsx
@@ -14,7 +14,9 @@ import Radio from '@mui/material/Radio'
 import RadioGroup from '@mui/material/RadioGroup'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
+import { useTheme } from '@mui/material/styles'
 import type { Group, Program } from '../types'
+import { getGroupChipColors } from '../theme'
 
 const filter = createFilterOptions<string>()
 const EMPTY_IDS: number[] = []
@@ -48,6 +50,8 @@ export default function AddCategoryDialog({
   groups = [],
   inheritedGroupIds = EMPTY_IDS,
 }: AddCategoryDialogProps) {
+  const theme = useTheme()
+  const groupColors = getGroupChipColors(theme.palette.mode)
   const [label, setLabel] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
@@ -242,16 +246,27 @@ export default function AddCategoryDialog({
                 {groups.map((g) => {
                   const disabled = inheritedGroupIds.length > 0 && !inheritedGroupIds.includes(g.id)
                   const isInheritedOnly = inheritedGroupIds.includes(g.id) && !selectedGroupIds.has(g.id)
+                  const isSelected = selectedGroupIds.has(g.id)
+                  const isActive = isSelected || isInheritedOnly
                   return (
                     <Chip
                       key={g.id}
                       label={g.name}
                       size="small"
-                      color={selectedGroupIds.has(g.id) || isInheritedOnly ? 'secondary' : 'default'}
-                      variant={selectedGroupIds.has(g.id) || isInheritedOnly ? 'filled' : 'outlined'}
+                      variant={isActive ? 'filled' : 'outlined'}
                       onClick={disabled ? undefined : () => toggleGroup(g.id)}
                       disabled={disabled}
-                      sx={isInheritedOnly ? { opacity: 0.5 } : undefined}
+                      sx={
+                        isActive
+                          ? {
+                              bgcolor: isSelected ? groupColors.solidBg : groupColors.subtleBg,
+                              color: isSelected ? groupColors.solidText : groupColors.subtleText,
+                              '& .MuiChip-label': {
+                                color: isSelected ? groupColors.solidText : groupColors.subtleText,
+                              },
+                            }
+                          : undefined
+                      }
                     />
                   )
                 })}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -91,6 +91,7 @@ export default function AppShell(props: AppShellProps) {
         onReportIssue,
         children,
     } = props;
+    const groupColors = getGroupChipColors(mode);
 
     const [manageMenuAnchor, setManageMenuAnchor] =
         useState<HTMLElement | null>(null);
@@ -299,8 +300,8 @@ export default function AppShell(props: AppShellProps) {
                                                     label={name}
                                                     size="small"
                                                     sx={{
-                                                        bgcolor: getGroupChipColors(mode).bg,
-                                                        color: getGroupChipColors(mode).text,
+                                                        bgcolor: groupColors.solidBg,
+                                                        color: groupColors.solidText,
                                                     }}
                                                 />
                                             ))}

--- a/frontend/src/components/EditCategoryDialog.tsx
+++ b/frontend/src/components/EditCategoryDialog.tsx
@@ -14,7 +14,9 @@ import Radio from '@mui/material/Radio'
 import RadioGroup from '@mui/material/RadioGroup'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
+import { useTheme } from '@mui/material/styles'
 import type { Group, Program } from '../types'
+import { getGroupChipColors } from '../theme'
 
 const filter = createFilterOptions<string>()
 
@@ -51,6 +53,8 @@ export default function EditCategoryDialog({
   currentGroupIds = [],
   inheritedGroupIds = [],
 }: EditCategoryDialogProps) {
+  const theme = useTheme()
+  const groupColors = getGroupChipColors(theme.palette.mode)
   const [label, setLabel] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
@@ -276,16 +280,27 @@ export default function EditCategoryDialog({
                 {groups.map((g) => {
                   const disabled = inheritedGroupIds.length > 0 && !inheritedGroupIds.includes(g.id)
                   const isInheritedOnly = inheritedGroupIds.includes(g.id) && !selectedGroupIds.has(g.id)
+                  const isSelected = selectedGroupIds.has(g.id)
+                  const isActive = isSelected || isInheritedOnly
                   return (
                     <Chip
                       key={g.id}
                       label={g.name}
                       size="small"
-                      color={selectedGroupIds.has(g.id) || isInheritedOnly ? 'secondary' : 'default'}
-                      variant={selectedGroupIds.has(g.id) || isInheritedOnly ? 'filled' : 'outlined'}
+                      variant={isActive ? 'filled' : 'outlined'}
                       onClick={disabled ? undefined : () => toggleGroup(g.id)}
                       disabled={disabled}
-                      sx={isInheritedOnly ? { opacity: 0.5 } : undefined}
+                      sx={
+                        isActive
+                          ? {
+                              bgcolor: isSelected ? groupColors.solidBg : groupColors.subtleBg,
+                              color: isSelected ? groupColors.solidText : groupColors.subtleText,
+                              '& .MuiChip-label': {
+                                color: isSelected ? groupColors.solidText : groupColors.subtleText,
+                              },
+                            }
+                          : undefined
+                      }
                     />
                   )
                 })}

--- a/frontend/src/components/GroupManagementModal.tsx
+++ b/frontend/src/components/GroupManagementModal.tsx
@@ -47,7 +47,7 @@ import {
 } from '../api'
 import type { ApiProgram, ApiUser } from '../api'
 import { apiGroupToGroup } from '../groupUtils'
-import { getVisibilityColors } from '../theme'
+import { getGroupChipColors } from '../theme'
 import type { Group } from '../types'
 
 interface GroupManagementModalProps {
@@ -86,8 +86,7 @@ export default function GroupManagementModal({
 }: GroupManagementModalProps) {
   const theme = useTheme()
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'))
-  const visColors = getVisibilityColors(theme.palette.mode)
-  const selectedGroupBg = alpha(visColors.inactiveChipBg, 0.5)
+  const groupColors = getGroupChipColors(theme.palette.mode)
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null)
   const [mobileDetailOpen, setMobileDetailOpen] = useState(false)
 
@@ -514,6 +513,7 @@ export default function GroupManagementModal({
             <Box sx={{ p: 2, pb: 1.5 }}>
               <Button
                 variant="contained"
+                color="secondary"
                 fullWidth
                 startIcon={<AddIcon />}
                 onClick={openCreateDialog}
@@ -546,12 +546,11 @@ export default function GroupManagementModal({
                         borderRadius: 1,
                         mb: 0.5,
                         '&.Mui-selected': {
-                          bgcolor: selectedGroupBg,
-                          color: '#fff',
-                          opacity: 0.5,
-                          '&:hover': { bgcolor: selectedGroupBg },
+                          bgcolor: groupColors.subtleBg,
+                          color: groupColors.subtleText,
+                          '&:hover': { bgcolor: groupColors.subtleBg },
                           '& .MuiListItemText-secondary': {
-                            color: alpha('#fff', 0.72),
+                            color: alpha(groupColors.subtleText, 0.72),
                           },
                         },
                       }}
@@ -660,6 +659,7 @@ export default function GroupManagementModal({
                     />
                     <Button
                       variant="contained"
+                      color="secondary"
                       startIcon={bulkPending ? <CircularProgress size={16} /> : <AddIcon />}
                       disabled={selectedUserIds.size === 0 || bulkPending || !manageable}
                       onClick={() => void handleBulkAdd()}

--- a/frontend/src/components/GroupManagementModal.tsx
+++ b/frontend/src/components/GroupManagementModal.tsx
@@ -47,6 +47,7 @@ import {
 } from '../api'
 import type { ApiProgram, ApiUser } from '../api'
 import { apiGroupToGroup } from '../groupUtils'
+import { getVisibilityColors } from '../theme'
 import type { Group } from '../types'
 
 interface GroupManagementModalProps {
@@ -85,6 +86,8 @@ export default function GroupManagementModal({
 }: GroupManagementModalProps) {
   const theme = useTheme()
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'))
+  const visColors = getVisibilityColors(theme.palette.mode)
+  const selectedGroupBg = alpha(visColors.inactiveChipBg, 0.5)
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null)
   const [mobileDetailOpen, setMobileDetailOpen] = useState(false)
 
@@ -448,7 +451,7 @@ export default function GroupManagementModal({
                 key={programId}
                 label={programNameById.get(programId) ?? `#${programId}`}
                 size="small"
-                variant="outlined"
+                color="primary"
               />
             ))}
           </Stack>
@@ -543,11 +546,12 @@ export default function GroupManagementModal({
                         borderRadius: 1,
                         mb: 0.5,
                         '&.Mui-selected': {
-                          bgcolor: 'primary.main',
-                          color: 'primary.contrastText',
-                          '&:hover': { bgcolor: 'primary.dark' },
+                          bgcolor: selectedGroupBg,
+                          color: '#fff',
+                          opacity: 0.5,
+                          '&:hover': { bgcolor: selectedGroupBg },
                           '& .MuiListItemText-secondary': {
-                            color: (theme) => alpha(theme.palette.primary.contrastText, 0.72),
+                            color: alpha('#fff', 0.72),
                           },
                         },
                       }}

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,4 +1,4 @@
-import { createTheme, type ThemeOptions } from '@mui/material/styles'
+import { alpha, createTheme, type ThemeOptions } from '@mui/material/styles'
 
 // ---------------------------------------------------------------------------
 // Colour palettes – edit these values to adjust light / dark appearance.
@@ -28,11 +28,16 @@ const lightPalette = {
   /** Custom surface used for the People / Admin pages. */
   surfaceVariant: '#DAC7B5',
   /**
-   * Group membership chip. White on #5B6973 ≈ 5.6:1 contrast (WCAG-AA for
-   * normal text). Distinct from the brand-red program chips so the two
-   * visibility dimensions read differently.
+   * Groups use the secondary palette as their brand colour. The subtle
+   * variant is a low-alpha fill with dark text so inherited/read-only states
+   * stay WCAG-AA compliant without relying on whole-chip opacity.
    */
-  groupChip: { bg: '#5B6973', text: '#FFFFFF' },
+  groupChip: {
+    solidBg: '#7F665D',
+    solidText: '#FFFFFF',
+    subtleBg: alpha('#7F665D', 0.16),
+    subtleText: '#3E3C3A',
+  },
   /**
    * Visibility status colours. Active uses a neutral dark-grey so the
    * default "visible" state stays unremarkable; inactive uses text.primary
@@ -63,10 +68,16 @@ const darkPalette = {
   /** Custom surface used for the People / Admin pages. */
   surfaceVariant: '#3A3230',
   /**
-   * Group membership chip (dark mode). A lighter slate that stays legible on
-   * the dark paper; dark text on #8A99A6 ≈ 5.5:1 contrast (WCAG-AA).
+   * Groups use the secondary palette as their brand colour in dark mode too.
+   * The subtle variant keeps light text over a low-alpha fill so it remains
+   * WCAG-AA compliant on dark paper.
    */
-  groupChip: { bg: '#8A99A6', text: '#1E1E1E' },
+  groupChip: {
+    solidBg: '#A89288',
+    solidText: '#1E1E1E',
+    subtleBg: alpha('#A89288', 0.16),
+    subtleText: '#E0DDD9',
+  },
   /**
    * Visibility status colours (dark mode). Active uses a neutral
    * light-grey; inactive uses text.primary at 0.6 alpha (#E0DDD999)
@@ -110,13 +121,15 @@ export function getSurfaceVariant(mode: 'light' | 'dark'): string {
 }
 
 /**
- * Group membership chip colours for the current mode. Background is #5B6973
- * in light mode (per design) and a WCAG-AA compliant lighter slate in dark
- * mode; `text` is the matching contrast colour.
+ * Group colours for the current mode. `solid*` is the primary group colour
+ * treatment; `subtle*` is the lower-emphasis version for inherited/read-only
+ * states that still meets WCAG-AA contrast.
  */
 export function getGroupChipColors(mode: 'light' | 'dark'): {
-  bg: string
-  text: string
+  solidBg: string
+  solidText: string
+  subtleBg: string
+  subtleText: string
 } {
   return mode === 'dark' ? darkPalette.groupChip : lightPalette.groupChip
 }

--- a/frontend/tests/components/GroupManagementModal.test.tsx
+++ b/frontend/tests/components/GroupManagementModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import GroupManagementModal from '../../src/components/GroupManagementModal'
 import type { ApiGroup, ApiProgram, ApiUser, UserListParams } from '../../src/api'
@@ -173,6 +173,30 @@ describe('GroupManagementModal', () => {
     expect(mockFetchUsersPaged).toHaveBeenCalledWith(
       expect.objectContaining({ role: 'student', page: 1, pageSize: 25 }),
     )
+  })
+
+  it('renders the selected group row with inactive grey background and half opacity', async () => {
+    renderModal()
+
+    expect(await screen.findByText('CURRENT MEMBERS')).toBeInTheDocument()
+
+    const selectedGroupRow = screen.getAllByText('Cohort A')[0].closest('.MuiListItemButton-root')
+    expect(selectedGroupRow).not.toBeNull()
+    expect(selectedGroupRow).toHaveStyle({
+      backgroundColor: 'rgba(107, 105, 102, 0.5)',
+      color: 'rgb(255, 255, 255)',
+      opacity: '0.5',
+    })
+  })
+
+  it('renders table program chips with the standard primary filled styling', async () => {
+    renderModal()
+
+    const studentRow = (await screen.findByText('Student One')).closest('tr')
+    expect(studentRow).not.toBeNull()
+
+    const programChip = within(studentRow as HTMLElement).getByText('Program A')
+    expect(programChip.closest('.MuiChip-root')).toHaveClass('MuiChip-filledPrimary')
   })
 
   it('shows an empty state when there are no groups', () => {

--- a/frontend/tests/components/GroupManagementModal.test.tsx
+++ b/frontend/tests/components/GroupManagementModal.test.tsx
@@ -175,7 +175,7 @@ describe('GroupManagementModal', () => {
     )
   })
 
-  it('renders the selected group row with inactive grey background and half opacity', async () => {
+  it('renders the selected group row with the subtle secondary group colour', async () => {
     renderModal()
 
     expect(await screen.findByText('CURRENT MEMBERS')).toBeInTheDocument()
@@ -183,10 +183,18 @@ describe('GroupManagementModal', () => {
     const selectedGroupRow = screen.getAllByText('Cohort A')[0].closest('.MuiListItemButton-root')
     expect(selectedGroupRow).not.toBeNull()
     expect(selectedGroupRow).toHaveStyle({
-      backgroundColor: 'rgba(107, 105, 102, 0.5)',
-      color: 'rgb(255, 255, 255)',
-      opacity: '0.5',
+      backgroundColor: 'rgba(127, 102, 93, 0.16)',
+      color: 'rgb(62, 60, 58)',
     })
+  })
+
+  it('renders the create and add actions with the strong secondary button colour', async () => {
+    renderModal()
+
+    expect(await screen.findByText('CURRENT MEMBERS')).toBeInTheDocument()
+
+    expect(screen.getByRole('button', { name: /create group/i })).toHaveClass('MuiButton-containedSecondary')
+    expect(screen.getByRole('button', { name: /add to group/i })).toHaveClass('MuiButton-containedSecondary')
   })
 
   it('renders table program chips with the standard primary filled styling', async () => {

--- a/frontend/tests/theme.test.ts
+++ b/frontend/tests/theme.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { buildTheme, getSurfaceVariant, getVisibilityColors } from "../src/theme";
+import { buildTheme, getGroupChipColors, getSurfaceVariant, getVisibilityColors } from "../src/theme";
 
 describe("buildTheme", () => {
     it("returns a theme with palette.mode === 'light' for light mode", () => {
@@ -65,5 +65,23 @@ describe("getVisibilityColors", () => {
         expect(c.active).toBe("rgba(255,255,255,0.70)");
         expect(c.inactive).toBe("#E0DDD999");
         expect(c.inactiveChipBg).toBe("#6B6966");
+    });
+});
+
+describe("getGroupChipColors", () => {
+    it("returns light-mode group colours based on the secondary palette", () => {
+        const c = getGroupChipColors("light");
+        expect(c.solidBg).toBe("#7F665D");
+        expect(c.solidText).toBe("#FFFFFF");
+        expect(c.subtleBg).toBe("rgba(127, 102, 93, 0.16)");
+        expect(c.subtleText).toBe("#3E3C3A");
+    });
+
+    it("returns dark-mode group colours based on the secondary palette", () => {
+        const c = getGroupChipColors("dark");
+        expect(c.solidBg).toBe("#A89288");
+        expect(c.solidText).toBe("#1E1E1E");
+        expect(c.subtleBg).toBe("rgba(168, 146, 136, 0.16)");
+        expect(c.subtleText).toBe("#E0DDD9");
     });
 });


### PR DESCRIPTION
Moves forward the Groups concept, making it easier for Instructors to identify and manage groups based on colour palette.

See `docs/groups.md` for Groups concept details.

This PR focuses on standardizing the styling for groups across the Home, Images, and People pages, as well as in the Manage Groups modal.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bcit-tlu/hriv/pull/656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->