### PR TITLE
fix: avoid visibility toggle refresh flash

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -152,8 +152,10 @@ export default function App() {
     const {
         categories,
         categoriesLoading,
+        setCategories,
         uncategorizedImages,
         uncategorizedLoaded,
+        setUncategorizedImages,
         programs,
         groups,
         setGroups,
@@ -374,7 +376,9 @@ export default function App() {
         handleDeleteBrowseImage,
     } = useImageActions({
         categories,
+        setCategories,
         uncategorizedImages,
+        setUncategorizedImages,
         selectedImage,
         setSelectedImage,
         setPath,
@@ -1080,6 +1084,13 @@ export default function App() {
                                                         label={p.name}
                                                         size="small"
                                                         color="primary"
+                                                        sx={
+                                                            selectedImage.active
+                                                                ? undefined
+                                                                : {
+                                                                      filter: "grayscale(100%)",
+                                                                  }
+                                                        }
                                                     />
                                                 ))}
                                                 {overflow > 0 && (
@@ -1099,6 +1110,11 @@ export default function App() {
                                                             aria-label={`${overflow} more programs`}
                                                             sx={{
                                                                 cursor: "pointer",
+                                                                ...(selectedImage.active
+                                                                    ? {}
+                                                                    : {
+                                                                          filter: "grayscale(100%)",
+                                                                      }),
                                                             }}
                                                         />
                                                         <Popover
@@ -1144,6 +1160,13 @@ export default function App() {
                                                                             }
                                                                             size="small"
                                                                             color="primary"
+                                                                            sx={
+                                                                                selectedImage.active
+                                                                                    ? undefined
+                                                                                    : {
+                                                                                          filter: "grayscale(100%)",
+                                                                                      }
+                                                                            }
                                                                         />
                                                                     ),
                                                                 )}
@@ -1191,6 +1214,13 @@ export default function App() {
                                                         label={g.name}
                                                         size="small"
                                                         color="secondary"
+                                                        sx={
+                                                            selectedImage.active
+                                                                ? undefined
+                                                                : {
+                                                                      filter: "grayscale(100%)",
+                                                                  }
+                                                        }
                                                     />
                                                 ))}
                                                 {overflow > 0 && (
@@ -1210,6 +1240,11 @@ export default function App() {
                                                             aria-label={`${overflow} more groups`}
                                                             sx={{
                                                                 cursor: "pointer",
+                                                                ...(selectedImage.active
+                                                                    ? {}
+                                                                    : {
+                                                                          filter: "grayscale(100%)",
+                                                                      }),
                                                             }}
                                                         />
                                                         <Popover
@@ -1255,6 +1290,13 @@ export default function App() {
                                                                             }
                                                                             size="small"
                                                                             color="secondary"
+                                                                            sx={
+                                                                                selectedImage.active
+                                                                                    ? undefined
+                                                                                    : {
+                                                                                          filter: "grayscale(100%)",
+                                                                                      }
+                                                                            }
                                                                         />
                                                                     ),
                                                                 )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
@@ -111,6 +111,15 @@ export default function App() {
     const [selectedImage, setSelectedImage] = useState<ImageItem | null>(null);
     const selectedImageRef = useRef<ImageItem | null>(null);
     selectedImageRef.current = selectedImage;
+    const inactiveViewerActionSx = useMemo(
+        () =>
+            selectedImage?.active
+                ? undefined
+                : {
+                      filter: "grayscale(100%)",
+                  },
+        [selectedImage?.active],
+    );
     const [dialogOpen, setDialogOpen] = useState(false);
     const [uploadOpen, setUploadOpen] = useState(false);
     const [fileDropCategoryId, setFileDropCategoryId] = useState<
@@ -1351,6 +1360,7 @@ export default function App() {
                                                         setImageEditOpen(true)
                                                     }
                                                     disabled={canvasEditActive}
+                                                    sx={inactiveViewerActionSx}
                                                 >
                                                     Edit Details
                                                 </Button>
@@ -1362,6 +1372,7 @@ export default function App() {
                                             variant="outlined"
                                             startIcon={<LinkIcon />}
                                             onClick={copyShareLink}
+                                            sx={inactiveViewerActionSx}
                                         >
                                             Share View
                                         </Button>

--- a/frontend/src/components/ManagePage.tsx
+++ b/frontend/src/components/ManagePage.tsx
@@ -472,10 +472,32 @@ export default function ManagePage({
 
   // Toggle active status via switch
   const handleToggleActive = async (image: ApiImage) => {
+    const nextActive = !image.active
+    setImages((prev) =>
+      prev.map((item) =>
+        item.id === image.id ? { ...item, active: nextActive } : item,
+      ),
+    )
     try {
-      await updateImage(image.id, { active: !image.active })
-      await loadImages()
+      const updated = await updateImage(image.id, { active: nextActive }, image.version)
+      setImages((prev) =>
+        prev.map((item) =>
+          item.id === image.id
+            ? {
+                ...item,
+                active: updated.active,
+                version: updated.version,
+                updated_at: updated.updated_at,
+              }
+            : item,
+        ),
+      )
     } catch (err) {
+      setImages((prev) =>
+        prev.map((item) =>
+          item.id === image.id ? { ...item, active: image.active } : item,
+        ),
+      )
       console.error('Failed to toggle image status', err)
     }
   }
@@ -875,6 +897,7 @@ export default function ManagePage({
                         borderRadius: 0.5,
                         display: 'block',
                         cursor: onViewImage ? 'pointer' : 'default',
+                        ...(img.active ? {} : { filter: 'grayscale(100%)' }),
                       }}
                     />
                   </TableCell>

--- a/frontend/src/treeUtils.ts
+++ b/frontend/src/treeUtils.ts
@@ -32,6 +32,21 @@ export function findCategoryPath(
     return null;
 }
 
+/** Return a new tree with a single image updated by ID. */
+export function updateImageInTree(
+    tree: Category[],
+    imageId: number,
+    updater: (image: ImageItem) => ImageItem,
+): Category[] {
+    return tree.map((category) => ({
+        ...category,
+        images: category.images.map((image) =>
+            image.id === imageId ? updater(image) : image,
+        ),
+        children: updateImageInTree(category.children, imageId, updater),
+    }));
+}
+
 /** Walk the category tree following an ordered list of IDs to reconstruct a path. */
 export function resolveCategoryPath(tree: Category[], ids: number[]): Category[] {
     const result: Category[] = [];

--- a/frontend/src/treeUtils.ts
+++ b/frontend/src/treeUtils.ts
@@ -38,13 +38,32 @@ export function updateImageInTree(
     imageId: number,
     updater: (image: ImageItem) => ImageItem,
 ): Category[] {
-    return tree.map((category) => ({
-        ...category,
-        images: category.images.map((image) =>
-            image.id === imageId ? updater(image) : image,
-        ),
-        children: updateImageInTree(category.children, imageId, updater),
-    }));
+    let changed = false;
+    const nextTree = tree.map((category) => {
+        let categoryChanged = false;
+
+        const nextImages = category.images.map((image) => {
+            if (image.id !== imageId) return image;
+            categoryChanged = true;
+            return updater(image);
+        });
+
+        const nextChildren = updateImageInTree(category.children, imageId, updater);
+        if (nextChildren !== category.children) {
+            categoryChanged = true;
+        }
+
+        if (!categoryChanged) return category;
+
+        changed = true;
+        return {
+            ...category,
+            images: nextImages,
+            children: nextChildren,
+        };
+    });
+
+    return changed ? nextTree : tree;
 }
 
 /** Walk the category tree following an ordered list of IDs to reconstruct a path. */

--- a/frontend/src/useBrowseData.ts
+++ b/frontend/src/useBrowseData.ts
@@ -244,8 +244,10 @@ export function useBrowseData({ path, currentUser }: UseBrowseDataDeps) {
     return {
         categories,
         categoriesLoading,
+        setCategories,
         uncategorizedImages,
         uncategorizedLoaded,
+        setUncategorizedImages,
         programs,
         groups,
         setGroups,

--- a/frontend/src/useImageActions.ts
+++ b/frontend/src/useImageActions.ts
@@ -8,11 +8,13 @@ import {
 import type { ApiImage } from "./api";
 import type { ImageFormData, ReplaceImageData } from "./components/EditImageModal";
 import type { Category, ImageItem } from "./types";
-import { findImageInTree, findCategoryPath } from "./treeUtils";
+import { findCategoryPath, findImageInTree, updateImageInTree } from "./treeUtils";
 
 export interface UseImageActionsDeps {
     categories: Category[];
+    setCategories: React.Dispatch<React.SetStateAction<Category[]>>;
     uncategorizedImages: ImageItem[];
+    setUncategorizedImages: React.Dispatch<React.SetStateAction<ImageItem[]>>;
     selectedImage: ImageItem | null;
     setSelectedImage: React.Dispatch<React.SetStateAction<ImageItem | null>>;
     setPath: React.Dispatch<React.SetStateAction<Category[]>>;
@@ -34,7 +36,9 @@ export interface UseImageActionsDeps {
 export function useImageActions(deps: UseImageActionsDeps) {
     const {
         categories,
+        setCategories,
         uncategorizedImages,
+        setUncategorizedImages,
         selectedImage,
         setSelectedImage,
         setPath,
@@ -53,32 +57,62 @@ export function useImageActions(deps: UseImageActionsDeps) {
     const [imageEditOpen, setImageEditOpen] = useState(false);
     const [browseEditImage, setBrowseEditImage] = useState<ImageItem | null>(null);
 
+    const patchLocalImage = useCallback(
+        (imageId: number, updater: (image: ImageItem) => ImageItem) => {
+            setCategories((prev) => updateImageInTree(prev, imageId, updater));
+            setUncategorizedImages((prev) =>
+                prev.map((image) => (image.id === imageId ? updater(image) : image)),
+            );
+            setSelectedImage((prev) =>
+                prev && prev.id === imageId ? updater(prev) : prev,
+            );
+        },
+        [setCategories, setSelectedImage, setUncategorizedImages],
+    );
+
     const toggleImageVisibility = useCallback(
         async (imageId: number) => {
+            const found = findImageInTree(categories, imageId);
+            const img =
+                found?.image ??
+                uncategorizedImages.find((i) => i.id === imageId) ??
+                (selectedImage?.id === imageId ? selectedImage : null);
+            if (!img) return;
+
+            const nextActive = !img.active;
+            patchLocalImage(imageId, (image) => ({
+                ...image,
+                active: nextActive,
+            }));
             try {
-                const found = findImageInTree(categories, imageId);
-                const img =
-                    found?.image ??
-                    uncategorizedImages.find((i) => i.id === imageId);
-                if (!img) return;
                 const updated = await apiUpdateImage(
                     imageId,
-                    { active: !img.active },
+                    { active: nextActive },
                     img.version,
                 );
-                setSelectedImage((prev) =>
-                    prev && prev.id === imageId
-                        ? { ...prev, active: updated.active, version: updated.version }
-                        : prev,
-                );
-                await loadCategories();
-                loadUncategorizedImages();
+                patchLocalImage(imageId, (image) => ({
+                    ...image,
+                    active: updated.active,
+                    version: updated.version,
+                    updatedAt: updated.updated_at,
+                }));
             } catch (err) {
+                patchLocalImage(imageId, (image) => ({
+                    ...image,
+                    active: img.active,
+                    version: img.version,
+                }));
                 console.error("Failed to toggle image visibility", err);
                 setErrorSnack(userMessage(err, "Failed to toggle image visibility."));
             }
         },
-        [categories, uncategorizedImages, loadCategories, loadUncategorizedImages, setSelectedImage, setErrorSnack],
+        [
+            categories,
+            uncategorizedImages,
+            selectedImage,
+            patchLocalImage,
+            setErrorSnack,
+        ],
     );
 
     const selectedApiImage: ApiImage | null = useMemo(

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -332,8 +332,12 @@ describe('App breadcrumbs', () => {
 
     const programChip = within(imageBreadcrumb as HTMLElement).getByText('Pathology').closest('.MuiChip-root')
     const groupChip = within(imageBreadcrumb as HTMLElement).getByText('Lab A2').closest('.MuiChip-root')
+    const editButton = screen.getByRole('button', { name: 'Edit Details' })
+    const shareButton = screen.getByText('Share View').closest('button')
 
     expect(programChip).toHaveStyle({ filter: 'grayscale(100%)' })
     expect(groupChip).toHaveStyle({ filter: 'grayscale(100%)' })
+    expect(editButton).toHaveStyle({ filter: 'grayscale(100%)' })
+    expect(shareButton).toHaveStyle({ filter: 'grayscale(100%)' })
   })
 })

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -1,5 +1,5 @@
 import { createRef, type ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import App from '../src/App'
 
@@ -247,8 +247,10 @@ vi.mock('../src/useBrowseData', () => ({
   useBrowseData: () => ({
     categories: mockCategories,
     categoriesLoading: false,
+    setCategories: vi.fn(),
     uncategorizedImages: [],
     uncategorizedLoaded: true,
+    setUncategorizedImages: vi.fn(),
     programs: mockPrograms,
     groups: mockGroups,
     ...browseDataFns,
@@ -299,6 +301,10 @@ vi.mock('../src/useCategoryActions', () => ({
 }))
 
 describe('App breadcrumbs', () => {
+  beforeEach(() => {
+    mockImage.active = true
+  })
+
   it('renders program and group chips in both browse and image breadcrumb rows', () => {
     render(<App />)
 
@@ -313,5 +319,21 @@ describe('App breadcrumbs', () => {
     expect(imageBreadcrumb).not.toBeNull()
     expect(within(imageBreadcrumb as HTMLElement).getByText('Pathology')).toBeInTheDocument()
     expect(within(imageBreadcrumb as HTMLElement).getByText('Lab A2')).toBeInTheDocument()
+  })
+
+  it('desaturates program and group chips in the image breadcrumb when the image is inactive', () => {
+    mockImage.active = false
+
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open image' }))
+
+    const imageBreadcrumb = screen.getByLabelText('image breadcrumb').closest('div')
+    expect(imageBreadcrumb).not.toBeNull()
+
+    const programChip = within(imageBreadcrumb as HTMLElement).getByText('Pathology').closest('.MuiChip-root')
+    const groupChip = within(imageBreadcrumb as HTMLElement).getByText('Lab A2').closest('.MuiChip-root')
+
+    expect(programChip).toHaveStyle({ filter: 'grayscale(100%)' })
+    expect(groupChip).toHaveStyle({ filter: 'grayscale(100%)' })
   })
 })

--- a/frontend/tests/components/ManagePage.test.tsx
+++ b/frontend/tests/components/ManagePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 vi.mock('../../src/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/api')>()
@@ -14,7 +14,7 @@ vi.mock('../../src/api', async (importOriginal) => {
   }
 })
 
-import { fetchImages } from '../../src/api'
+import { fetchImages, updateImage } from '../../src/api'
 import type { Group, Program } from '../../src/types'
 import { makeCategory } from '../helpers/fixtures'
 import ManagePage from '../../src/components/ManagePage'
@@ -71,5 +71,67 @@ describe('ManagePage', () => {
     expect(screen.getByText('Groups')).toBeInTheDocument()
     const groupChip = screen.getByText('Lab A2').closest('.MuiChip-root')
     expect(groupChip).toBeInTheDocument()
+  })
+
+  it('greyscales the thumbnail when an image is inactive', async () => {
+    vi.mocked(fetchImages).mockResolvedValue([
+      {
+        id: 101,
+        name: 'Blood Smear',
+        thumb: '/thumb.jpg',
+        tile_sources: '/tile.dzi',
+        category_id: 10,
+        copyright: null,
+        note: null,
+        active: false,
+        sort_order: 0,
+        metadata_extra: null,
+        version: 1,
+        width: null,
+        height: null,
+        file_size: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z',
+      },
+    ])
+
+    render(<ManagePage categories={categories} programs={programs} groups={groups} />)
+
+    const thumbnail = await screen.findByAltText('Blood Smear')
+    expect(thumbnail).toHaveStyle({ filter: 'grayscale(100%)' })
+  })
+
+  it('toggles visibility without refetching the image list', async () => {
+    vi.mocked(updateImage).mockResolvedValue({
+      id: 101,
+      name: 'Blood Smear',
+      thumb: '/thumb.jpg',
+      tile_sources: '/tile.dzi',
+      category_id: 10,
+      copyright: null,
+      note: null,
+      active: false,
+      sort_order: 0,
+      metadata_extra: null,
+      version: 2,
+      width: null,
+      height: null,
+      file_size: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-03T00:00:00Z',
+    })
+
+    const { container } = render(<ManagePage categories={categories} programs={programs} groups={groups} />)
+
+    await screen.findByText('Blood Smear')
+    const checkboxes = Array.from(container.querySelectorAll('input[type="checkbox"]'))
+    const toggle = checkboxes.find((input) => input.checked)
+    expect(toggle).toBeDefined()
+    fireEvent.click(toggle!)
+
+    await waitFor(() => {
+      expect(updateImage).toHaveBeenCalledWith(101, { active: false }, 1)
+    })
+    expect(fetchImages).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/tests/treeUtils.test.ts
+++ b/frontend/tests/treeUtils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { findImageInTree, findCategoryPath, resolveCategoryPath } from "../src/treeUtils";
+import {
+    findImageInTree,
+    findCategoryPath,
+    resolveCategoryPath,
+    updateImageInTree,
+} from "../src/treeUtils";
 import { makeCategory, makeImage } from "./helpers/fixtures";
 
 describe("findImageInTree", () => {
@@ -99,5 +104,87 @@ describe("resolveCategoryPath", () => {
     it("returns empty when first ID does not match", () => {
         const cat = makeCategory({ id: 1, label: "Root" });
         expect(resolveCategoryPath([cat], [999])).toEqual([]);
+    });
+});
+
+describe("updateImageInTree", () => {
+    it("updates an image at the root level", () => {
+        const rootImage = makeImage({ id: 42, name: "Before" });
+        const tree = [
+            makeCategory({ id: 1, label: "Root", images: [rootImage] }),
+        ];
+
+        const updated = updateImageInTree(tree, 42, (image) => ({
+            ...image,
+            name: "After",
+        }));
+
+        expect(updated[0].images[0].name).toBe("After");
+        expect(tree[0].images[0].name).toBe("Before");
+    });
+
+    it("updates an image in a nested category", () => {
+        const nestedImage = makeImage({ id: 99, active: true });
+        const tree = [
+            makeCategory({
+                id: 1,
+                label: "Root",
+                children: [
+                    makeCategory({
+                        id: 2,
+                        label: "Child",
+                        images: [nestedImage],
+                    }),
+                ],
+            }),
+        ];
+
+        const updated = updateImageInTree(tree, 99, (image) => ({
+            ...image,
+            active: false,
+        }));
+
+        expect(updated[0].children[0].images[0].active).toBe(false);
+        expect(tree[0].children[0].images[0].active).toBe(true);
+    });
+
+    it("returns an unchanged tree when the image ID does not exist", () => {
+        const tree = [
+            makeCategory({
+                id: 1,
+                images: [makeImage({ id: 10, name: "Only Image" })],
+            }),
+        ];
+
+        const updated = updateImageInTree(tree, 999, (image) => ({
+            ...image,
+            name: "Updated",
+        }));
+
+        expect(updated).toEqual(tree);
+        expect(updated).toBe(tree);
+    });
+
+    it("only updates the matching image when multiple images exist", () => {
+        const firstImage = makeImage({ id: 1, name: "First" });
+        const secondImage = makeImage({ id: 2, name: "Second" });
+        const thirdImage = makeImage({ id: 3, name: "Third" });
+        const tree = [
+            makeCategory({
+                id: 1,
+                images: [firstImage, secondImage, thirdImage],
+            }),
+        ];
+
+        const updated = updateImageInTree(tree, 2, (image) => ({
+            ...image,
+            name: "Second Updated",
+        }));
+
+        expect(updated[0].images.map((image) => image.name)).toEqual([
+            "First",
+            "Second Updated",
+            "Third",
+        ]);
     });
 });

--- a/frontend/tests/useImageActions.test.ts
+++ b/frontend/tests/useImageActions.test.ts
@@ -22,7 +22,9 @@ const mockReplaceImage = vi.mocked(api.replaceImage);
 function makeDeps(overrides: Partial<UseImageActionsDeps> = {}): UseImageActionsDeps {
     return {
         categories: [],
+        setCategories: vi.fn(),
         uncategorizedImages: [],
+        setUncategorizedImages: vi.fn(),
         selectedImage: null,
         setSelectedImage: vi.fn(),
         setPath: vi.fn(),
@@ -152,7 +154,7 @@ describe("useImageActions", () => {
     });
 
     describe("toggleImageVisibility", () => {
-        it("toggles active flag and reloads", async () => {
+        it("toggles active flag locally without reloading", async () => {
             const img = makeImage({ id: 10, active: true, version: 2 });
             const catA = makeCategory({ id: 1, images: [img] });
             const deps = makeDeps({ categories: [catA] });
@@ -181,8 +183,10 @@ describe("useImageActions", () => {
             });
 
             expect(mockUpdateImage).toHaveBeenCalledWith(10, { active: false }, 2);
-            expect(deps.loadCategories).toHaveBeenCalled();
-            expect(deps.loadUncategorizedImages).toHaveBeenCalled();
+            expect(deps.setCategories).toHaveBeenCalled();
+            expect(deps.setUncategorizedImages).toHaveBeenCalled();
+            expect(deps.loadCategories).not.toHaveBeenCalled();
+            expect(deps.loadUncategorizedImages).not.toHaveBeenCalled();
         });
 
         it("finds image in uncategorized when not in tree", async () => {


### PR DESCRIPTION
## Summary
- remove the image visibility toggle flash by updating viewer state locally instead of reloading browse data
- update the Manage Images visibility switch optimistically so rows and thumbnails update in place
- add targeted tests for the no-refetch behavior and the grayscale inactive-state rendering

## Testing
- nix-shell --run "cd frontend && npm test -- tests/useImageActions.test.ts tests/components/ManagePage.test.tsx tests/App.test.tsx && npm run build"