### PR TITLE
feat: add persisted table column choosers

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -64,6 +64,27 @@ All seed users share the password `password`.
 
 ---
 
+## Test Case 3b: Table Column Preference Persistence Per User
+
+**Purpose:** Verify that table column visibility preferences persist across logout/login for the same user without leaking to other users.
+
+1. Login as `admin@example.ca` / `password`.
+2. Open the `Images` tab.
+3. Open the column chooser and enable the `Program` column.
+4. **Assert:** The Images table now shows the `Program` column.
+5. Click Logout.
+6. Login again as `admin@example.ca` / `password`.
+7. Open the `Images` tab.
+8. **Assert:** The `Program` column is still visible.
+9. Click Logout.
+10. Login as `student@example.ca` / `password`, then logout again.
+11. Login as `admin@example.ca` / `password`.
+12. **Assert:** The `Program` column preference is still preserved for the admin user.
+13. Open the `People` tab.
+14. **Assert:** The default visible columns are `Name`, `Email`, `Role`, `Program`, and `Last Accessed`.
+
+---
+
 ## Test Case 4: CLI Access via curl — Authentication and RBAC Enforcement
 
 **Purpose:** Verify API authentication and role-based access control work via command-line HTTP requests.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -24,6 +24,10 @@ export function getToken(): string | null {
  * Remove all HRIV-scoped localStorage keys (`hriv_*` and `hriv-*`).
  * Called on logout and when a different user logs in to prevent
  * cross-account state leakage on shared browsers.
+ *
+ * Deliberately excludes `hrivpref:` UI preference keys because those are
+ * already user-scoped (for example, persisted table column selections) and
+ * should survive logout/login cycles for the same browser profile.
  */
 export function clearUserStorage(): void {
   const keysToRemove: string[] = []

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -24,6 +24,7 @@ import SearchIcon from "@mui/icons-material/Search";
 import ColorModeToggle from "./ColorModeToggle";
 import AnnouncementBanner from "./AnnouncementBanner";
 import type { Role } from "../types";
+import { getSurfaceVariant } from "../theme";
 
 export type Page = "browse" | "manage" | "people" | "admin";
 
@@ -95,6 +96,10 @@ export default function AppShell(props: AppShellProps) {
     const [viewAnnOpen, setViewAnnOpen] = useState(false);
     const [annCollapsed, setAnnCollapsed] = useState(false);
     const showViewAnnLink = annEnabled && !announcement;
+    const contentBg =
+        page === "people" || page === "admin"
+            ? getSurfaceVariant(mode)
+            : undefined;
 
     useEffect(() => {
         if (announcement) setAnnCollapsed(false);
@@ -359,8 +364,18 @@ export default function AppShell(props: AppShellProps) {
             {/* Announcement banner */}
             {announcement && (
                 <Collapse in={!annCollapsed} onExited={onDismissAnnouncement}>
-                    <Box sx={{ mx: '10%', mt: '20px', mb: 0 }}>
-                        <AnnouncementBanner message={announcement} onDismiss={onDismissAnnouncement ? () => setAnnCollapsed(true) : undefined} />
+                    <Box
+                        sx={{
+                            bgcolor: contentBg,
+                            pt: "20px",
+                        }}
+                    >
+                        <Box sx={{ mx: "10%", mb: 0 }}>
+                            <AnnouncementBanner
+                                message={announcement}
+                                onDismiss={onDismissAnnouncement ? () => setAnnCollapsed(true) : undefined}
+                            />
+                        </Box>
                     </Box>
                 </Collapse>
             )}

--- a/frontend/src/components/ColumnVisibilityDialog.tsx
+++ b/frontend/src/components/ColumnVisibilityDialog.tsx
@@ -1,0 +1,56 @@
+import Button from '@mui/material/Button'
+import Checkbox from '@mui/material/Checkbox'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import FormGroup from '@mui/material/FormGroup'
+
+export interface ColumnVisibilityOption<Key extends string> {
+  key: Key
+  label: string
+}
+
+interface ColumnVisibilityDialogProps<Key extends string> {
+  open: boolean
+  title: string
+  columns: readonly ColumnVisibilityOption<Key>[]
+  visibleColumns: Record<Key, boolean>
+  onClose: () => void
+  onToggleColumn: (column: Key) => void
+}
+
+export default function ColumnVisibilityDialog<Key extends string>({
+  open,
+  title,
+  columns,
+  visibleColumns,
+  onClose,
+  onToggleColumn,
+}: ColumnVisibilityDialogProps<Key>) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent dividers>
+        <FormGroup>
+          {columns.map((column) => (
+            <FormControlLabel
+              key={column.key}
+              control={
+                <Checkbox
+                  checked={visibleColumns[column.key]}
+                  onChange={() => onToggleColumn(column.key)}
+                />
+              }
+              label={column.label}
+            />
+          ))}
+        </FormGroup>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Done</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/ManagePage.tsx
+++ b/frontend/src/components/ManagePage.tsx
@@ -28,7 +28,8 @@ import TablePagination from '@mui/material/TablePagination'
 import TableRow from '@mui/material/TableRow'
 import TableSortLabel from '@mui/material/TableSortLabel'
 import TextField from '@mui/material/TextField'
-import Tooltip from '@mui/material/Tooltip'
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Chip from '@mui/material/Chip'
 import Typography from '@mui/material/Typography'
 import type { SelectChangeEvent } from '@mui/material/Select'
@@ -40,13 +41,16 @@ import FilterListIcon from '@mui/icons-material/FilterList'
 import InfoIcon from '@mui/icons-material/Info'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import VisibilityIcon from '@mui/icons-material/Visibility'
+import ViewColumnIcon from '@mui/icons-material/ViewColumn'
 import { fetchImages, updateImage, deleteImage, replaceImage, bulkUpdateImages, bulkDeleteImages } from '../api'
 import type { ApiBulkImportJob, ApiImage } from '../api'
 import type { Category, Group, Program } from '../types'
 import { splitDirectAncestorGroupIds, splitDirectAncestorProgramIds } from '../categoryUtils'
 import { getGroupChipColors, getVisibilityColors } from '../theme'
+import { useTableColumnPreferences } from '../useTableColumnPreferences'
 import { useColorMode } from '../useColorMode'
 import BulkEditImagesModal from './BulkEditImagesModal'
+import ColumnVisibilityDialog, { type ColumnVisibilityOption } from './ColumnVisibilityDialog'
 import EditImageModal from './EditImageModal'
 import type { ImageFormData, ReplaceImageData } from './EditImageModal'
 import MoveImageDialog from './MoveImageDialog'
@@ -118,6 +122,51 @@ function CategoryBreadcrumb({
 
 type SortableColumn = 'id' | 'name' | 'category' | 'copyright' | 'note' | 'program' | 'group' | 'active' | 'updated_at'
 type SortDirection = 'asc' | 'desc'
+type ManageTableColumn =
+  | 'thumbnail'
+  | 'id'
+  | 'name'
+  | 'category'
+  | 'copyright'
+  | 'note'
+  | 'program'
+  | 'group'
+  | 'active'
+  | 'updated_at'
+
+const MANAGE_COLUMN_OPTIONS: readonly ColumnVisibilityOption<ManageTableColumn>[] = [
+  { key: 'thumbnail', label: 'Thumbnail' },
+  { key: 'id', label: 'ID' },
+  { key: 'name', label: 'Name' },
+  { key: 'category', label: 'Category' },
+  { key: 'copyright', label: 'Copyright' },
+  { key: 'note', label: 'Note' },
+  { key: 'program', label: 'Program' },
+  { key: 'group', label: 'Groups' },
+  { key: 'active', label: 'Visibility' },
+  { key: 'updated_at', label: 'Modified' },
+]
+
+const MANAGE_DEFAULT_VISIBLE_COLUMNS: readonly ManageTableColumn[] = [
+  'thumbnail',
+  'name',
+  'category',
+  'group',
+  'active',
+  'updated_at',
+]
+const MANAGE_ALL_COLUMNS: readonly ManageTableColumn[] = MANAGE_COLUMN_OPTIONS.map((column) => column.key)
+
+const MANAGE_COLUMN_FILTER_KEYS: Partial<Record<ManageTableColumn, string>> = {
+  id: 'id',
+  name: 'name',
+  category: 'category',
+  copyright: 'copyright',
+  note: 'note',
+  program: 'program',
+  group: 'group',
+  active: 'active',
+}
 
 interface ManagePageProps {
   categories: Category[]
@@ -216,6 +265,16 @@ export default function ManagePage({
 
   // Filter row visibility
   const [showFilters, setShowFilters] = useState(false)
+  const [columnDialogOpen, setColumnDialogOpen] = useState(false)
+  const {
+    visibleColumns,
+    isColumnVisible,
+    setColumnVisible,
+  } = useTableColumnPreferences<ManageTableColumn>({
+    tableKey: 'manage-images',
+    allColumns: MANAGE_ALL_COLUMNS,
+    defaultVisibleColumns: MANAGE_DEFAULT_VISIBLE_COLUMNS,
+  })
 
   // Pagination state
   const [rowsPerPage, setRowsPerPage] = useState(25)
@@ -387,6 +446,22 @@ export default function ManagePage({
     setFilters({})
     setCurrentPage(0)
   }
+
+  const handleColumnVisibilityToggle = useCallback((column: ManageTableColumn) => {
+    const nextVisible = !visibleColumns[column]
+    setColumnVisible(column, nextVisible)
+    if (!nextVisible) {
+      const filterKey = MANAGE_COLUMN_FILTER_KEYS[column]
+      if (filterKey) {
+        setFilters((prev) => {
+          if (!prev[filterKey]) return prev
+          const next = { ...prev }
+          delete next[filterKey]
+          return next
+        })
+      }
+    }
+  }, [setColumnVisible, visibleColumns])
 
   const pageImages = sortedImages.slice(currentPage * rowsPerPage, currentPage * rowsPerPage + rowsPerPage)
 
@@ -605,25 +680,28 @@ export default function ManagePage({
           Images
         </Typography>
         <Box sx={{ display: 'flex', gap: 2, flexShrink: 0, alignItems: 'center' }}>
-          <Tooltip title={showFilters ? 'Hide filters' : 'Show filters'}>
-            <IconButton
+          <ToggleButtonGroup size="small" aria-label="Image table controls">
+            <ToggleButton
+              value="filters"
+              selected={showFilters || hasActiveFilters}
               size="small"
-              onClick={() => setShowFilters((prev) => !prev)}
-              color={showFilters || hasActiveFilters ? 'primary' : 'default'}
+              title={showFilters ? 'Hide filters' : 'Show filters'}
               aria-label={showFilters ? 'Hide filters' : 'Show filters'}
-              sx={
-                hasActiveFilters
-                  ? {
-                      bgcolor: 'primary.main',
-                      color: 'primary.contrastText',
-                      '&:hover': { bgcolor: 'primary.dark' },
-                    }
-                  : undefined
-              }
+              onClick={() => setShowFilters((prev) => !prev)}
             >
-              <FilterListIcon />
-            </IconButton>
-          </Tooltip>
+              <FilterListIcon fontSize="small" />
+            </ToggleButton>
+            <ToggleButton
+              value="columns"
+              selected={columnDialogOpen}
+              size="small"
+              title="Choose columns"
+              aria-label="Choose columns"
+              onClick={() => setColumnDialogOpen(true)}
+            >
+              <ViewColumnIcon fontSize="small" />
+            </ToggleButton>
+          </ToggleButtonGroup>
           {selected.size > 0 && (
             <Button
               variant="contained"
@@ -660,8 +738,8 @@ export default function ManagePage({
                     onChange={(e) => handleSelectAll(e.target.checked)}
                   />
                 </TableCell>
-                <TableCell sx={{ width: 48, p: 0.5 }} />
-                <TableCell sortDirection={sortColumn === 'id' ? sortDirection : false}>
+                {isColumnVisible('thumbnail') && <TableCell sx={{ width: 48, p: 0.5 }} />}
+                {isColumnVisible('id') && <TableCell sortDirection={sortColumn === 'id' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'id'}
                     direction={sortColumn === 'id' ? sortDirection : 'asc'}
@@ -669,8 +747,8 @@ export default function ManagePage({
                   >
                     ID
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'name' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('name') && <TableCell sortDirection={sortColumn === 'name' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'name'}
                     direction={sortColumn === 'name' ? sortDirection : 'asc'}
@@ -678,8 +756,8 @@ export default function ManagePage({
                   >
                     Name
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'category' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('category') && <TableCell sortDirection={sortColumn === 'category' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'category'}
                     direction={sortColumn === 'category' ? sortDirection : 'asc'}
@@ -687,8 +765,8 @@ export default function ManagePage({
                   >
                     Category
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'copyright' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('copyright') && <TableCell sortDirection={sortColumn === 'copyright' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'copyright'}
                     direction={sortColumn === 'copyright' ? sortDirection : 'asc'}
@@ -696,8 +774,8 @@ export default function ManagePage({
                   >
                     Copyright
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'note' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('note') && <TableCell sortDirection={sortColumn === 'note' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'note'}
                     direction={sortColumn === 'note' ? sortDirection : 'asc'}
@@ -705,8 +783,8 @@ export default function ManagePage({
                   >
                     Note
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'program' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('program') && <TableCell sortDirection={sortColumn === 'program' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'program'}
                     direction={sortColumn === 'program' ? sortDirection : 'asc'}
@@ -714,8 +792,8 @@ export default function ManagePage({
                   >
                     Program
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'group' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('group') && <TableCell sortDirection={sortColumn === 'group' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'group'}
                     direction={sortColumn === 'group' ? sortDirection : 'asc'}
@@ -723,8 +801,8 @@ export default function ManagePage({
                   >
                     Groups
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'active' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('active') && <TableCell sortDirection={sortColumn === 'active' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'active'}
                     direction={sortColumn === 'active' ? sortDirection : 'asc'}
@@ -732,8 +810,8 @@ export default function ManagePage({
                   >
                     Visibility
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'updated_at' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('updated_at') && <TableCell sortDirection={sortColumn === 'updated_at' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'updated_at'}
                     direction={sortColumn === 'updated_at' ? sortDirection : 'asc'}
@@ -741,7 +819,7 @@ export default function ManagePage({
                   >
                     Modified
                   </TableSortLabel>
-                </TableCell>
+                </TableCell>}
                 <TableCell align="right">Actions</TableCell>
               </TableRow>
               {showFilters && (
@@ -753,8 +831,8 @@ export default function ManagePage({
                     </IconButton>
                   )}
                 </TableCell>
-                <TableCell />
-                <TableCell>
+                {isColumnVisible('thumbnail') && <TableCell />}
+                {isColumnVisible('id') && <TableCell>
                   <TextField
                     size="small"
                     variant="standard"
@@ -764,8 +842,8 @@ export default function ManagePage({
                     slotProps={{ input: { sx: { fontSize: '0.8rem' } } }}
                     InputProps={filters['id'] ? { endAdornment: <InputAdornment position="end"><IconButton size="small" onClick={() => handleFilterChange('id', '')}><ClearIcon sx={{ fontSize: 14 }} /></IconButton></InputAdornment> } : undefined}
                   />
-                </TableCell>
-                <TableCell>
+                </TableCell>}
+                {isColumnVisible('name') && <TableCell>
                   <TextField
                     size="small"
                     variant="standard"
@@ -775,8 +853,8 @@ export default function ManagePage({
                     slotProps={{ input: { sx: { fontSize: '0.8rem' } } }}
                     InputProps={filters['name'] ? { endAdornment: <InputAdornment position="end"><IconButton size="small" onClick={() => handleFilterChange('name', '')}><ClearIcon sx={{ fontSize: 14 }} /></IconButton></InputAdornment> } : undefined}
                   />
-                </TableCell>
-                <TableCell>
+                </TableCell>}
+                {isColumnVisible('category') && <TableCell>
                   <TextField
                     size="small"
                     variant="standard"
@@ -786,8 +864,8 @@ export default function ManagePage({
                     slotProps={{ input: { sx: { fontSize: '0.8rem' } } }}
                     InputProps={filters['category'] ? { endAdornment: <InputAdornment position="end"><IconButton size="small" onClick={() => handleFilterChange('category', '')}><ClearIcon sx={{ fontSize: 14 }} /></IconButton></InputAdornment> } : undefined}
                   />
-                </TableCell>
-                <TableCell>
+                </TableCell>}
+                {isColumnVisible('copyright') && <TableCell>
                   <TextField
                     size="small"
                     variant="standard"
@@ -797,8 +875,8 @@ export default function ManagePage({
                     slotProps={{ input: { sx: { fontSize: '0.8rem' } } }}
                     InputProps={filters['copyright'] ? { endAdornment: <InputAdornment position="end"><IconButton size="small" onClick={() => handleFilterChange('copyright', '')}><ClearIcon sx={{ fontSize: 14 }} /></IconButton></InputAdornment> } : undefined}
                   />
-                </TableCell>
-                <TableCell>
+                </TableCell>}
+                {isColumnVisible('note') && <TableCell>
                   <TextField
                     size="small"
                     variant="standard"
@@ -808,8 +886,8 @@ export default function ManagePage({
                     slotProps={{ input: { sx: { fontSize: '0.8rem' } } }}
                     InputProps={filters['note'] ? { endAdornment: <InputAdornment position="end"><IconButton size="small" onClick={() => handleFilterChange('note', '')}><ClearIcon sx={{ fontSize: 14 }} /></IconButton></InputAdornment> } : undefined}
                   />
-                </TableCell>
-                <TableCell>
+                </TableCell>}
+                {isColumnVisible('program') && <TableCell>
                   <TextField
                     size="small"
                     variant="standard"
@@ -819,8 +897,8 @@ export default function ManagePage({
                     slotProps={{ input: { sx: { fontSize: '0.8rem' } } }}
                     InputProps={filters['program'] ? { endAdornment: <InputAdornment position="end"><IconButton size="small" onClick={() => handleFilterChange('program', '')}><ClearIcon sx={{ fontSize: 14 }} /></IconButton></InputAdornment> } : undefined}
                   />
-                </TableCell>
-                <TableCell>
+                </TableCell>}
+                {isColumnVisible('group') && <TableCell>
                   <TextField
                     size="small"
                     variant="standard"
@@ -830,8 +908,8 @@ export default function ManagePage({
                     slotProps={{ input: { sx: { fontSize: '0.8rem' } } }}
                     InputProps={filters['group'] ? { endAdornment: <InputAdornment position="end"><IconButton size="small" onClick={() => handleFilterChange('group', '')}><ClearIcon sx={{ fontSize: 14 }} /></IconButton></InputAdornment> } : undefined}
                   />
-                </TableCell>
-                <TableCell>
+                </TableCell>}
+                {isColumnVisible('active') && <TableCell>
                   <FormControl size="small" variant="standard" fullWidth>
                     <Select
                       value={filters['active'] ?? ''}
@@ -844,8 +922,8 @@ export default function ManagePage({
                       <MenuItem value="inactive">Inactive</MenuItem>
                     </Select>
                   </FormControl>
-                </TableCell>
-                <TableCell />
+                </TableCell>}
+                {isColumnVisible('updated_at') && <TableCell />}
                 <TableCell />
               </TableRow>
               )}
@@ -876,7 +954,7 @@ export default function ManagePage({
                       }
                     />
                   </TableCell>
-                  <TableCell
+                  {isColumnVisible('thumbnail') && <TableCell
                     data-interactive="true"
                     sx={{ p: 0.5 }}
                     onClick={(e) => {
@@ -900,19 +978,19 @@ export default function ManagePage({
                         ...(img.active ? {} : { filter: 'grayscale(100%)' }),
                       }}
                     />
-                  </TableCell>
-                  <TableCell>{img.id}</TableCell>
-                  <TableCell>{img.name}</TableCell>
-                  <TableCell>
+                  </TableCell>}
+                  {isColumnVisible('id') && <TableCell>{img.id}</TableCell>}
+                  {isColumnVisible('name') && <TableCell>{img.name}</TableCell>}
+                  {isColumnVisible('category') && <TableCell>
                     <CategoryBreadcrumb
                       categoryId={img.category_id}
                       categoryPaths={categoryPaths}
                       onNavigate={onNavigateCategory}
                     />
-                  </TableCell>
-                  <TableCell>{img.copyright ?? '—'}</TableCell>
-                  <TableCell>{img.note ?? '—'}</TableCell>
-                  <TableCell onClick={(e) => e.stopPropagation()}>
+                  </TableCell>}
+                  {isColumnVisible('copyright') && <TableCell>{img.copyright ?? '—'}</TableCell>}
+                  {isColumnVisible('note') && <TableCell>{img.note ?? '—'}</TableCell>}
+                  {isColumnVisible('program') && <TableCell onClick={(e) => e.stopPropagation()}>
                     {(() => {
                       const { direct, ancestor } = getInheritedProgramIds(img)
                       if (direct.length === 0 && ancestor.length === 0) return 'All programs'
@@ -959,8 +1037,8 @@ export default function ManagePage({
                         </Box>
                       )
                     })()}
-                  </TableCell>
-                  <TableCell onClick={(e) => e.stopPropagation()}>
+                  </TableCell>}
+                  {isColumnVisible('group') && <TableCell onClick={(e) => e.stopPropagation()}>
                     {(() => {
                       const { direct, ancestor } = getInheritedGroupIds(img)
                       if (direct.length === 0 && ancestor.length === 0) return 'All groups'
@@ -1019,8 +1097,8 @@ export default function ManagePage({
                         </Box>
                       )
                     })()}
-                  </TableCell>
-                  <TableCell
+                  </TableCell>}
+                  {isColumnVisible('active') && <TableCell
                     data-interactive="true"
                     onClick={(e) => e.stopPropagation()}
                   >
@@ -1029,10 +1107,10 @@ export default function ManagePage({
                       checked={img.active}
                       onChange={() => handleToggleActive(img)}
                     />
-                  </TableCell>
-                  <TableCell>
+                  </TableCell>}
+                  {isColumnVisible('updated_at') && <TableCell>
                     {new Date(img.updated_at).toLocaleDateString()}
-                  </TableCell>
+                  </TableCell>}
                   <TableCell
                     data-interactive="true"
                     align="right"
@@ -1064,6 +1142,15 @@ export default function ManagePage({
           />
         </TableContainer>
       )}
+
+      <ColumnVisibilityDialog
+        open={columnDialogOpen}
+        title="Choose image table columns"
+        columns={MANAGE_COLUMN_OPTIONS}
+        visibleColumns={visibleColumns}
+        onClose={() => setColumnDialogOpen(false)}
+        onToggleColumn={handleColumnVisibilityToggle}
+      />
 
       {/* Action menu */}
       <Menu

--- a/frontend/src/components/ManagePage.tsx
+++ b/frontend/src/components/ManagePage.tsx
@@ -686,19 +686,19 @@ export default function ManagePage({
             aria-label="Image table controls"
             sx={{
               '& .MuiToggleButton-root': (theme) => ({
-                bgcolor: alpha(theme.palette.text.primary, 0.08),
+                bgcolor: alpha(theme.palette.text.primary, 0.09),
                 color: theme.palette.text.primary,
-                borderColor: alpha(theme.palette.text.primary, 0.18),
+                borderColor: alpha(theme.palette.text.primary, 0.2),
                 '&:hover': {
-                  bgcolor: alpha(theme.palette.text.primary, 0.12),
+                  bgcolor: alpha(theme.palette.text.primary, 0.13),
                 },
               }),
               '& .MuiToggleButton-root.Mui-selected': (theme) => ({
-                bgcolor: alpha(theme.palette.text.primary, 0.14),
+                bgcolor: alpha(theme.palette.text.primary, 0.15),
                 color: theme.palette.text.primary,
-                borderColor: alpha(theme.palette.text.primary, 0.24),
+                borderColor: alpha(theme.palette.text.primary, 0.26),
                 '&:hover': {
-                  bgcolor: alpha(theme.palette.text.primary, 0.14),
+                  bgcolor: alpha(theme.palette.text.primary, 0.17),
                 },
               }),
             }}

--- a/frontend/src/components/ManagePage.tsx
+++ b/frontend/src/components/ManagePage.tsx
@@ -684,21 +684,21 @@ export default function ManagePage({
             size="small"
             aria-label="Image table controls"
             sx={{
-              '& .MuiToggleButton-root': {
-                bgcolor: 'grey.200',
-                color: 'text.primary',
-                borderColor: 'grey.300',
+              '& .MuiToggleButton-root': (theme) => ({
+                bgcolor: theme.palette.mode === 'dark' ? '#4A4442' : '#DAC7B5',
+                color: theme.palette.text.primary,
+                borderColor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
                 '&:hover': {
-                  bgcolor: 'grey.300',
+                  bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
                 },
-              },
-              '& .MuiToggleButton-root.Mui-selected': {
-                bgcolor: 'grey.300',
-                color: 'text.primary',
+              }),
+              '& .MuiToggleButton-root.Mui-selected': (theme) => ({
+                bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
+                color: theme.palette.text.primary,
                 '&:hover': {
-                  bgcolor: 'grey.300',
+                  bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
                 },
-              },
+              }),
             }}
           >
             <ToggleButton

--- a/frontend/src/components/ManagePage.tsx
+++ b/frontend/src/components/ManagePage.tsx
@@ -680,7 +680,27 @@ export default function ManagePage({
           Images
         </Typography>
         <Box sx={{ display: 'flex', gap: 2, flexShrink: 0, alignItems: 'center' }}>
-          <ToggleButtonGroup size="small" aria-label="Image table controls">
+          <ToggleButtonGroup
+            size="small"
+            aria-label="Image table controls"
+            sx={{
+              '& .MuiToggleButton-root': {
+                bgcolor: 'grey.200',
+                color: 'text.primary',
+                borderColor: 'grey.300',
+                '&:hover': {
+                  bgcolor: 'grey.300',
+                },
+              },
+              '& .MuiToggleButton-root.Mui-selected': {
+                bgcolor: 'grey.300',
+                color: 'text.primary',
+                '&:hover': {
+                  bgcolor: 'grey.300',
+                },
+              },
+            }}
+          >
             <ToggleButton
               value="filters"
               selected={showFilters || hasActiveFilters}

--- a/frontend/src/components/ManagePage.tsx
+++ b/frontend/src/components/ManagePage.tsx
@@ -33,6 +33,7 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Chip from '@mui/material/Chip'
 import Typography from '@mui/material/Typography'
 import type { SelectChangeEvent } from '@mui/material/Select'
+import { alpha } from '@mui/material/styles'
 import AddPhotoAlternateIcon from '@mui/icons-material/AddPhotoAlternate'
 import ClearIcon from '@mui/icons-material/Clear'
 import DeleteIcon from '@mui/icons-material/Delete'
@@ -685,18 +686,19 @@ export default function ManagePage({
             aria-label="Image table controls"
             sx={{
               '& .MuiToggleButton-root': (theme) => ({
-                bgcolor: theme.palette.mode === 'dark' ? '#4A4442' : '#DAC7B5',
+                bgcolor: alpha(theme.palette.text.primary, 0.08),
                 color: theme.palette.text.primary,
-                borderColor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
+                borderColor: alpha(theme.palette.text.primary, 0.18),
                 '&:hover': {
-                  bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
+                  bgcolor: alpha(theme.palette.text.primary, 0.12),
                 },
               }),
               '& .MuiToggleButton-root.Mui-selected': (theme) => ({
-                bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
+                bgcolor: alpha(theme.palette.text.primary, 0.14),
                 color: theme.palette.text.primary,
+                borderColor: alpha(theme.palette.text.primary, 0.24),
                 '&:hover': {
-                  bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
+                  bgcolor: alpha(theme.palette.text.primary, 0.14),
                 },
               }),
             }}

--- a/frontend/src/components/ManagePage.tsx
+++ b/frontend/src/components/ManagePage.tsx
@@ -285,11 +285,12 @@ export default function ManagePage({
   useEffect(() => {
     if (initialProgramFilter) {
       setFilters((prev) => ({ ...prev, program: initialProgramFilter }))
+      setColumnVisible('program', true)
       setShowFilters(true)
       setCurrentPage(0)
       onInitialProgramFilterConsumed?.()
     }
-  }, [initialProgramFilter, onInitialProgramFilterConsumed])
+  }, [initialProgramFilter, onInitialProgramFilterConsumed, setColumnVisible])
 
   // Action menu state
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null)

--- a/frontend/src/components/PeoplePage.tsx
+++ b/frontend/src/components/PeoplePage.tsx
@@ -402,21 +402,21 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
             size="small"
             aria-label="People table controls"
             sx={{
-              '& .MuiToggleButton-root': {
-                bgcolor: 'grey.200',
-                color: 'text.primary',
-                borderColor: 'grey.300',
+              '& .MuiToggleButton-root': (theme) => ({
+                bgcolor: theme.palette.mode === 'dark' ? '#4A4442' : '#DAC7B5',
+                color: theme.palette.text.primary,
+                borderColor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
                 '&:hover': {
-                  bgcolor: 'grey.300',
+                  bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
                 },
-              },
-              '& .MuiToggleButton-root.Mui-selected': {
-                bgcolor: 'grey.300',
-                color: 'text.primary',
+              }),
+              '& .MuiToggleButton-root.Mui-selected': (theme) => ({
+                bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
+                color: theme.palette.text.primary,
                 '&:hover': {
-                  bgcolor: 'grey.300',
+                  bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
                 },
-              },
+              }),
             }}
           >
             <ToggleButton

--- a/frontend/src/components/PeoplePage.tsx
+++ b/frontend/src/components/PeoplePage.tsx
@@ -404,19 +404,19 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
             aria-label="People table controls"
             sx={{
               '& .MuiToggleButton-root': (theme) => ({
-                bgcolor: alpha(theme.palette.text.primary, 0.08),
+                bgcolor: alpha(theme.palette.text.primary, 0.09),
                 color: theme.palette.text.primary,
-                borderColor: alpha(theme.palette.text.primary, 0.18),
+                borderColor: alpha(theme.palette.text.primary, 0.2),
                 '&:hover': {
-                  bgcolor: alpha(theme.palette.text.primary, 0.12),
+                  bgcolor: alpha(theme.palette.text.primary, 0.13),
                 },
               }),
               '& .MuiToggleButton-root.Mui-selected': (theme) => ({
-                bgcolor: alpha(theme.palette.text.primary, 0.14),
+                bgcolor: alpha(theme.palette.text.primary, 0.15),
                 color: theme.palette.text.primary,
-                borderColor: alpha(theme.palette.text.primary, 0.24),
+                borderColor: alpha(theme.palette.text.primary, 0.26),
                 '&:hover': {
-                  bgcolor: alpha(theme.palette.text.primary, 0.14),
+                  bgcolor: alpha(theme.palette.text.primary, 0.17),
                 },
               }),
             }}

--- a/frontend/src/components/PeoplePage.tsx
+++ b/frontend/src/components/PeoplePage.tsx
@@ -398,7 +398,27 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
           People
         </Typography>
         <Box sx={{ display: 'flex', gap: 2, flexShrink: 0, alignItems: 'center' }}>
-          <ToggleButtonGroup size="small" aria-label="People table controls">
+          <ToggleButtonGroup
+            size="small"
+            aria-label="People table controls"
+            sx={{
+              '& .MuiToggleButton-root': {
+                bgcolor: 'grey.200',
+                color: 'text.primary',
+                borderColor: 'grey.300',
+                '&:hover': {
+                  bgcolor: 'grey.300',
+                },
+              },
+              '& .MuiToggleButton-root.Mui-selected': {
+                bgcolor: 'grey.300',
+                color: 'text.primary',
+                '&:hover': {
+                  bgcolor: 'grey.300',
+                },
+              },
+            }}
+          >
             <ToggleButton
               value="filters"
               selected={showFilters || hasActiveFilters}

--- a/frontend/src/components/PeoplePage.tsx
+++ b/frontend/src/components/PeoplePage.tsx
@@ -24,12 +24,14 @@ import TablePagination from '@mui/material/TablePagination'
 import TableRow from '@mui/material/TableRow'
 import TableSortLabel from '@mui/material/TableSortLabel'
 import TextField from '@mui/material/TextField'
-import Tooltip from '@mui/material/Tooltip'
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Typography from '@mui/material/Typography'
 import type { SelectChangeEvent } from '@mui/material/Select'
 import ClearIcon from '@mui/icons-material/Clear'
 import FilterListIcon from '@mui/icons-material/FilterList'
 import PersonAddIcon from '@mui/icons-material/PersonAdd'
+import ViewColumnIcon from '@mui/icons-material/ViewColumn'
 import {
   fetchUsers,
   createUser,
@@ -41,13 +43,51 @@ import {
 } from '../api'
 import type { ApiUser } from '../api'
 import type { Role, Program } from '../types'
+import { useTableColumnPreferences } from '../useTableColumnPreferences'
 import AddEditPersonModal from './AddEditPersonModal'
 import BulkEditModal from './BulkEditModal'
+import ColumnVisibilityDialog, { type ColumnVisibilityOption } from './ColumnVisibilityDialog'
 
 type SortableColumn = 'id' | 'name' | 'email' | 'role' | 'program' | 'group' | 'last_access' | 'created_at'
 type SortDirection = 'asc' | 'desc'
+type PeopleTableColumn =
+  | 'id'
+  | 'name'
+  | 'email'
+  | 'role'
+  | 'program'
+  | 'group'
+  | 'last_access'
+  | 'created_at'
 
 const ROLES: Role[] = ['admin', 'instructor', 'student']
+const PEOPLE_COLUMN_OPTIONS: readonly ColumnVisibilityOption<PeopleTableColumn>[] = [
+  { key: 'id', label: 'ID' },
+  { key: 'name', label: 'Name' },
+  { key: 'email', label: 'Email' },
+  { key: 'role', label: 'Role' },
+  { key: 'program', label: 'Program' },
+  { key: 'group', label: 'Groups' },
+  { key: 'last_access', label: 'Last Accessed' },
+  { key: 'created_at', label: 'Created' },
+]
+
+const PEOPLE_DEFAULT_VISIBLE_COLUMNS: readonly PeopleTableColumn[] = [
+  'name',
+  'email',
+  'role',
+  'program',
+  'last_access',
+]
+const PEOPLE_ALL_COLUMNS: readonly PeopleTableColumn[] = PEOPLE_COLUMN_OPTIONS.map((column) => column.key)
+
+const PEOPLE_COLUMN_FILTER_KEYS: Partial<Record<PeopleTableColumn, string>> = {
+  name: 'name',
+  email: 'email',
+  role: 'role',
+  program: 'program',
+  group: 'group',
+}
 
 interface PeoplePageProps {
   programs: Program[]
@@ -70,6 +110,16 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
 
   // Filter row visibility
   const [showFilters, setShowFilters] = useState(false)
+  const [columnDialogOpen, setColumnDialogOpen] = useState(false)
+  const {
+    visibleColumns,
+    isColumnVisible,
+    setColumnVisible,
+  } = useTableColumnPreferences<PeopleTableColumn>({
+    tableKey: 'people',
+    allColumns: PEOPLE_ALL_COLUMNS,
+    defaultVisibleColumns: PEOPLE_DEFAULT_VISIBLE_COLUMNS,
+  })
 
   // Pagination state
   const [rowsPerPage, setRowsPerPage] = useState(25)
@@ -202,6 +252,22 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
     setCurrentPage(0)
   }
 
+  const handleColumnVisibilityToggle = useCallback((column: PeopleTableColumn) => {
+    const nextVisible = !visibleColumns[column]
+    setColumnVisible(column, nextVisible)
+    if (!nextVisible) {
+      const filterKey = PEOPLE_COLUMN_FILTER_KEYS[column]
+      if (filterKey) {
+        setFilters((prev) => {
+          if (!prev[filterKey]) return prev
+          const next = { ...prev }
+          delete next[filterKey]
+          return next
+        })
+      }
+    }
+  }, [setColumnVisible, visibleColumns])
+
   const pageUsers = useMemo(
     () => sortedUsers.slice(currentPage * rowsPerPage, currentPage * rowsPerPage + rowsPerPage),
     [sortedUsers, currentPage, rowsPerPage],
@@ -332,25 +398,28 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
           People
         </Typography>
         <Box sx={{ display: 'flex', gap: 2, flexShrink: 0, alignItems: 'center' }}>
-          <Tooltip title={showFilters ? 'Hide filters' : 'Show filters'}>
-            <IconButton
+          <ToggleButtonGroup size="small" aria-label="People table controls">
+            <ToggleButton
+              value="filters"
+              selected={showFilters || hasActiveFilters}
               size="small"
-              onClick={() => setShowFilters((prev) => !prev)}
-              color={showFilters || hasActiveFilters ? 'primary' : 'default'}
+              title={showFilters ? 'Hide filters' : 'Show filters'}
               aria-label={showFilters ? 'Hide filters' : 'Show filters'}
-              sx={
-                hasActiveFilters
-                  ? {
-                      bgcolor: 'primary.main',
-                      color: 'primary.contrastText',
-                      '&:hover': { bgcolor: 'primary.dark' },
-                    }
-                  : undefined
-              }
+              onClick={() => setShowFilters((prev) => !prev)}
             >
-              <FilterListIcon />
-            </IconButton>
-          </Tooltip>
+              <FilterListIcon fontSize="small" />
+            </ToggleButton>
+            <ToggleButton
+              value="columns"
+              selected={columnDialogOpen}
+              size="small"
+              title="Choose columns"
+              aria-label="Choose columns"
+              onClick={() => setColumnDialogOpen(true)}
+            >
+              <ViewColumnIcon fontSize="small" />
+            </ToggleButton>
+          </ToggleButtonGroup>
           {selected.size > 0 && (
             <>
               <Button
@@ -405,7 +474,7 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                     onChange={(e) => handleSelectAll(e.target.checked)}
                   />
                 </TableCell>
-                <TableCell sortDirection={sortColumn === 'id' ? sortDirection : false}>
+                {isColumnVisible('id') && <TableCell sortDirection={sortColumn === 'id' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'id'}
                     direction={sortColumn === 'id' ? sortDirection : 'asc'}
@@ -413,8 +482,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                   >
                     ID
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'name' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('name') && <TableCell sortDirection={sortColumn === 'name' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'name'}
                     direction={sortColumn === 'name' ? sortDirection : 'asc'}
@@ -422,8 +491,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                   >
                     Name
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'email' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('email') && <TableCell sortDirection={sortColumn === 'email' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'email'}
                     direction={sortColumn === 'email' ? sortDirection : 'asc'}
@@ -431,8 +500,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                   >
                     Email
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'role' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('role') && <TableCell sortDirection={sortColumn === 'role' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'role'}
                     direction={sortColumn === 'role' ? sortDirection : 'asc'}
@@ -440,8 +509,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                   >
                     Role
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'program' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('program') && <TableCell sortDirection={sortColumn === 'program' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'program'}
                     direction={sortColumn === 'program' ? sortDirection : 'asc'}
@@ -449,8 +518,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                   >
                     Program
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'group' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('group') && <TableCell sortDirection={sortColumn === 'group' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'group'}
                     direction={sortColumn === 'group' ? sortDirection : 'asc'}
@@ -458,8 +527,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                   >
                     Groups
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'last_access' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('last_access') && <TableCell sortDirection={sortColumn === 'last_access' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'last_access'}
                     direction={sortColumn === 'last_access' ? sortDirection : 'asc'}
@@ -467,8 +536,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                   >
                     Last Accessed
                   </TableSortLabel>
-                </TableCell>
-                <TableCell sortDirection={sortColumn === 'created_at' ? sortDirection : false}>
+                </TableCell>}
+                {isColumnVisible('created_at') && <TableCell sortDirection={sortColumn === 'created_at' ? sortDirection : false}>
                   <TableSortLabel
                     active={sortColumn === 'created_at'}
                     direction={sortColumn === 'created_at' ? sortDirection : 'asc'}
@@ -476,7 +545,7 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                   >
                     Created
                   </TableSortLabel>
-                </TableCell>
+                </TableCell>}
                 <TableCell align="right">Actions</TableCell>
               </TableRow>
               {showFilters && (
@@ -488,8 +557,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                     </IconButton>
                   )}
                 </TableCell>
-                <TableCell />
-                <TableCell>
+                {isColumnVisible('id') && <TableCell />}
+                {isColumnVisible('name') && <TableCell>
                   <TextField
                     size="small"
                     variant="standard"
@@ -499,8 +568,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                     slotProps={{ input: { sx: { fontSize: '0.8rem' } } }}
                     InputProps={filters['name'] ? { endAdornment: <InputAdornment position="end"><IconButton size="small" onClick={() => handleFilterChange('name', '')}><ClearIcon sx={{ fontSize: 14 }} /></IconButton></InputAdornment> } : undefined}
                   />
-                </TableCell>
-                <TableCell>
+                </TableCell>}
+                {isColumnVisible('email') && <TableCell>
                   <TextField
                     size="small"
                     variant="standard"
@@ -510,8 +579,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                     slotProps={{ input: { sx: { fontSize: '0.8rem' } } }}
                     InputProps={filters['email'] ? { endAdornment: <InputAdornment position="end"><IconButton size="small" onClick={() => handleFilterChange('email', '')}><ClearIcon sx={{ fontSize: 14 }} /></IconButton></InputAdornment> } : undefined}
                   />
-                </TableCell>
-                <TableCell>
+                </TableCell>}
+                {isColumnVisible('role') && <TableCell>
                   <FormControl size="small" variant="standard" fullWidth>
                     <Select
                       value={filters['role'] ?? ''}
@@ -523,8 +592,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                       {ROLES.map((r) => <MenuItem key={r} value={r}>{r}</MenuItem>)}
                     </Select>
                   </FormControl>
-                </TableCell>
-                <TableCell>
+                </TableCell>}
+                {isColumnVisible('program') && <TableCell>
                   <TextField
                     size="small"
                     variant="standard"
@@ -534,8 +603,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                     slotProps={{ input: { sx: { fontSize: '0.8rem' } } }}
                     InputProps={filters['program'] ? { endAdornment: <InputAdornment position="end"><IconButton size="small" onClick={() => handleFilterChange('program', '')}><ClearIcon sx={{ fontSize: 14 }} /></IconButton></InputAdornment> } : undefined}
                   />
-                </TableCell>
-                <TableCell>
+                </TableCell>}
+                {isColumnVisible('group') && <TableCell>
                   <TextField
                     size="small"
                     variant="standard"
@@ -545,9 +614,9 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                     slotProps={{ input: { sx: { fontSize: '0.8rem' } } }}
                     InputProps={filters['group'] ? { endAdornment: <InputAdornment position="end"><IconButton size="small" onClick={() => handleFilterChange('group', '')}><ClearIcon sx={{ fontSize: 14 }} /></IconButton></InputAdornment> } : undefined}
                   />
-                </TableCell>
-                <TableCell />
-                <TableCell />
+                </TableCell>}
+                {isColumnVisible('last_access') && <TableCell />}
+                {isColumnVisible('created_at') && <TableCell />}
                 <TableCell />
               </TableRow>
               )}
@@ -572,11 +641,11 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                       }
                     />
                   </TableCell>
-                  <TableCell>{user.id}</TableCell>
-                  <TableCell>{user.name}</TableCell>
-                  <TableCell>{user.email}</TableCell>
-                  <TableCell>{user.role}</TableCell>
-                  <TableCell>
+                  {isColumnVisible('id') && <TableCell>{user.id}</TableCell>}
+                  {isColumnVisible('name') && <TableCell>{user.name}</TableCell>}
+                  {isColumnVisible('email') && <TableCell>{user.email}</TableCell>}
+                  {isColumnVisible('role') && <TableCell>{user.role}</TableCell>}
+                  {isColumnVisible('program') && <TableCell>
                     {user.program_names.length > 0 ? (
                       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                         {user.program_names.map((name) => (
@@ -584,8 +653,8 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                         ))}
                       </Box>
                     ) : '—'}
-                  </TableCell>
-                  <TableCell>
+                  </TableCell>}
+                  {isColumnVisible('group') && <TableCell>
                     {user.group_names.length > 0 ? (
                       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                         {user.group_names.map((name) => (
@@ -598,15 +667,15 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
                         ))}
                       </Box>
                     ) : '—'}
-                  </TableCell>
-                  <TableCell>
+                  </TableCell>}
+                  {isColumnVisible('last_access') && <TableCell>
                     {user.last_access
                       ? new Date(user.last_access).toLocaleDateString()
                       : '—'}
-                  </TableCell>
-                  <TableCell>
+                  </TableCell>}
+                  {isColumnVisible('created_at') && <TableCell>
                     {new Date(user.created_at).toLocaleDateString()}
-                  </TableCell>
+                  </TableCell>}
                   <TableCell
                     align="right"
                     onClick={(e) => e.stopPropagation()}
@@ -637,6 +706,15 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
           />
         </TableContainer>
       )}
+
+      <ColumnVisibilityDialog
+        open={columnDialogOpen}
+        title="Choose people table columns"
+        columns={PEOPLE_COLUMN_OPTIONS}
+        visibleColumns={visibleColumns}
+        onClose={() => setColumnDialogOpen(false)}
+        onToggleColumn={handleColumnVisibilityToggle}
+      />
 
       {/* Modals */}
       <AddEditPersonModal

--- a/frontend/src/components/PeoplePage.tsx
+++ b/frontend/src/components/PeoplePage.tsx
@@ -28,6 +28,7 @@ import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Typography from '@mui/material/Typography'
 import type { SelectChangeEvent } from '@mui/material/Select'
+import { alpha } from '@mui/material/styles'
 import ClearIcon from '@mui/icons-material/Clear'
 import FilterListIcon from '@mui/icons-material/FilterList'
 import PersonAddIcon from '@mui/icons-material/PersonAdd'
@@ -403,18 +404,19 @@ export default function PeoplePage({ programs, initialEditUserId, onEditUserHand
             aria-label="People table controls"
             sx={{
               '& .MuiToggleButton-root': (theme) => ({
-                bgcolor: theme.palette.mode === 'dark' ? '#4A4442' : '#DAC7B5',
+                bgcolor: alpha(theme.palette.text.primary, 0.08),
                 color: theme.palette.text.primary,
-                borderColor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
+                borderColor: alpha(theme.palette.text.primary, 0.18),
                 '&:hover': {
-                  bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
+                  bgcolor: alpha(theme.palette.text.primary, 0.12),
                 },
               }),
               '& .MuiToggleButton-root.Mui-selected': (theme) => ({
-                bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
+                bgcolor: alpha(theme.palette.text.primary, 0.14),
                 color: theme.palette.text.primary,
+                borderColor: alpha(theme.palette.text.primary, 0.24),
                 '&:hover': {
-                  bgcolor: theme.palette.mode === 'dark' ? '#5C5552' : '#CDB8A5',
+                  bgcolor: alpha(theme.palette.text.primary, 0.14),
                 },
               }),
             }}

--- a/frontend/src/useTableColumnPreferences.ts
+++ b/frontend/src/useTableColumnPreferences.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+type ColumnVisibilityMap<Key extends string> = Record<Key, boolean>
+
+interface UseTableColumnPreferencesArgs<Key extends string> {
+  tableKey: string
+  allColumns: readonly Key[]
+  defaultVisibleColumns: readonly Key[]
+}
+
+function getStoredUserScope(): string {
+  try {
+    const stored = localStorage.getItem('hriv_user')
+    if (!stored) return 'anonymous'
+    const parsed = JSON.parse(stored) as { id?: number | string }
+    return parsed.id != null ? String(parsed.id) : 'anonymous'
+  } catch {
+    return 'anonymous'
+  }
+}
+
+function buildDefaultVisibility<Key extends string>(
+  allColumns: readonly Key[],
+  defaultVisibleColumns: readonly Key[],
+): ColumnVisibilityMap<Key> {
+  return Object.fromEntries(
+    allColumns.map((column) => [column, defaultVisibleColumns.includes(column)]),
+  ) as ColumnVisibilityMap<Key>
+}
+
+function loadStoredVisibility<Key extends string>(
+  storageKey: string,
+  allColumns: readonly Key[],
+  defaultVisibility: ColumnVisibilityMap<Key>,
+): ColumnVisibilityMap<Key> {
+  try {
+    const stored = localStorage.getItem(storageKey)
+    if (!stored) return defaultVisibility
+    const parsed = JSON.parse(stored) as Partial<Record<Key, unknown>>
+    return Object.fromEntries(
+      allColumns.map((column) => [
+        column,
+        typeof parsed[column] === 'boolean'
+          ? (parsed[column] as boolean)
+          : defaultVisibility[column],
+      ]),
+    ) as ColumnVisibilityMap<Key>
+  } catch {
+    return defaultVisibility
+  }
+}
+
+export function useTableColumnPreferences<Key extends string>({
+  tableKey,
+  allColumns,
+  defaultVisibleColumns,
+}: UseTableColumnPreferencesArgs<Key>) {
+  const userScope = useMemo(() => getStoredUserScope(), [])
+  const storageKey = `hrivpref:table-columns:${tableKey}:user:${userScope}`
+  const defaultVisibility = useMemo(
+    () => buildDefaultVisibility(allColumns, defaultVisibleColumns),
+    [allColumns, defaultVisibleColumns],
+  )
+  const [visibleColumns, setVisibleColumns] =
+    useState<ColumnVisibilityMap<Key>>(() =>
+      loadStoredVisibility(storageKey, allColumns, defaultVisibility),
+    )
+
+  useEffect(() => {
+    setVisibleColumns(loadStoredVisibility(storageKey, allColumns, defaultVisibility))
+  }, [allColumns, defaultVisibility, storageKey])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(visibleColumns))
+    } catch {
+      // Ignore localStorage write failures and fall back to in-memory state.
+    }
+  }, [storageKey, visibleColumns])
+
+  const isColumnVisible = useCallback(
+    (column: Key) => visibleColumns[column],
+    [visibleColumns],
+  )
+
+  const setColumnVisible = useCallback((column: Key, visible: boolean) => {
+    setVisibleColumns((prev) => ({ ...prev, [column]: visible }))
+  }, [])
+
+  const toggleColumn = useCallback((column: Key) => {
+    setVisibleColumns((prev) => ({ ...prev, [column]: !prev[column] }))
+  }, [])
+
+  return {
+    visibleColumns,
+    isColumnVisible,
+    setColumnVisible,
+    toggleColumn,
+  }
+}

--- a/frontend/tests/components/ColumnVisibilityDialog.test.tsx
+++ b/frontend/tests/components/ColumnVisibilityDialog.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ColumnVisibilityDialog from '../../src/components/ColumnVisibilityDialog'
+
+type TestColumn = 'name' | 'email' | 'role'
+
+const columns = [
+  { key: 'name', label: 'Name' },
+  { key: 'email', label: 'Email' },
+  { key: 'role', label: 'Role' },
+] as const satisfies readonly { key: TestColumn, label: string }[]
+
+describe('ColumnVisibilityDialog', () => {
+  it('renders the dialog title and all column options', () => {
+    render(
+      <ColumnVisibilityDialog<TestColumn>
+        open
+        title="Choose columns"
+        columns={columns}
+        visibleColumns={{ name: true, email: false, role: true }}
+        onClose={vi.fn()}
+        onToggleColumn={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Choose columns')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Name' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Email' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Role' })).toBeChecked()
+  })
+
+  it('calls onToggleColumn when a checkbox is clicked', async () => {
+    const user = userEvent.setup()
+    const onToggleColumn = vi.fn()
+
+    render(
+      <ColumnVisibilityDialog<TestColumn>
+        open
+        title="Choose columns"
+        columns={columns}
+        visibleColumns={{ name: true, email: false, role: true }}
+        onClose={vi.fn()}
+        onToggleColumn={onToggleColumn}
+      />,
+    )
+
+    await user.click(screen.getByRole('checkbox', { name: 'Email' }))
+
+    expect(onToggleColumn).toHaveBeenCalledWith('email')
+  })
+
+  it('reflects updated checked state from visibleColumns props', () => {
+    const { rerender } = render(
+      <ColumnVisibilityDialog<TestColumn>
+        open
+        title="Choose columns"
+        columns={columns}
+        visibleColumns={{ name: true, email: false, role: true }}
+        onClose={vi.fn()}
+        onToggleColumn={vi.fn()}
+      />,
+    )
+
+    rerender(
+      <ColumnVisibilityDialog<TestColumn>
+        open
+        title="Choose columns"
+        columns={columns}
+        visibleColumns={{ name: false, email: true, role: true }}
+        onClose={vi.fn()}
+        onToggleColumn={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('checkbox', { name: 'Name' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Email' })).toBeChecked()
+  })
+
+  it('closes when the Done button is clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(
+      <ColumnVisibilityDialog<TestColumn>
+        open
+        title="Choose columns"
+        columns={columns}
+        visibleColumns={{ name: true, email: false, role: true }}
+        onClose={onClose}
+        onToggleColumn={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Done' }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/tests/components/ManagePage.test.tsx
+++ b/frontend/tests/components/ManagePage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 vi.mock('../../src/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/api')>()
@@ -39,6 +40,8 @@ const categories = [
 describe('ManagePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
+    localStorage.setItem('hriv_user', JSON.stringify({ id: 1 }))
     vi.mocked(fetchImages).mockResolvedValue([
       {
         id: 101,
@@ -71,6 +74,22 @@ describe('ManagePage', () => {
     expect(screen.getByText('Groups')).toBeInTheDocument()
     const groupChip = screen.getByText('Lab A2').closest('.MuiChip-root')
     expect(groupChip).toBeInTheDocument()
+  })
+
+  it('shows the configured default visible columns', async () => {
+    render(<ManagePage categories={categories} programs={programs} groups={groups} />)
+
+    await screen.findByText('Blood Smear')
+
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Category' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Groups' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Visibility' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Modified' })).toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'ID' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Program' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Copyright' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Note' })).not.toBeInTheDocument()
   })
 
   it('greyscales the thumbnail when an image is inactive', async () => {
@@ -133,5 +152,29 @@ describe('ManagePage', () => {
       expect(updateImage).toHaveBeenCalledWith(101, { active: false }, 1)
     })
     expect(fetchImages).toHaveBeenCalledTimes(1)
+  })
+
+  it('persists selected columns between renders', async () => {
+    const user = userEvent.setup()
+    const { unmount } = render(<ManagePage categories={categories} programs={programs} groups={groups} />)
+
+    await screen.findByText('Blood Smear')
+    expect(screen.queryByRole('columnheader', { name: 'Program' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Choose columns' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Choose image table columns' })
+    await user.click(within(dialog).getByRole('checkbox', { name: 'Program' }))
+    await user.click(within(dialog).getByRole('button', { name: 'Done' }))
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Choose image table columns' })).not.toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('columnheader', { name: 'Program' })).toBeInTheDocument()
+
+    unmount()
+    render(<ManagePage categories={categories} programs={programs} groups={groups} />)
+
+    await screen.findByText('Blood Smear')
+    expect(screen.getByRole('columnheader', { name: 'Program' })).toBeInTheDocument()
   })
 })

--- a/frontend/tests/components/PeoplePage.test.tsx
+++ b/frontend/tests/components/PeoplePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 vi.mock('../../src/api', async (importOriginal) => {
@@ -59,6 +59,8 @@ const USERS = [
 describe('PeoplePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
+    localStorage.setItem('hriv_user', JSON.stringify({ id: 1 }))
     vi.mocked(fetchUsers).mockResolvedValue(USERS)
   })
 
@@ -170,16 +172,21 @@ describe('PeoplePage', () => {
     expect(chip).toBeInTheDocument()
   })
 
-  it('displays group names as chips in the Groups column', async () => {
+  it('shows the configured default visible columns', async () => {
     render(<PeoplePage programs={programs} />)
 
     await waitFor(() => {
-      expect(screen.getByText('Lab A2')).toBeInTheDocument()
+      expect(screen.getByText('Admin User')).toBeInTheDocument()
     })
 
-    const chip = screen.getByText('Lab A2').closest('.MuiChip-root')
-    expect(chip).toBeInTheDocument()
-    expect(screen.getByText('Groups')).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Email' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Role' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Program' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Last Accessed' })).toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'ID' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Groups' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Created' })).not.toBeInTheDocument()
   })
 
   it('displays last accessed date when available', async () => {
@@ -204,9 +211,38 @@ describe('PeoplePage', () => {
     expect(screen.getByText('Email')).toBeInTheDocument()
     expect(screen.getByText('Role')).toBeInTheDocument()
     expect(screen.getByText('Program')).toBeInTheDocument()
-    expect(screen.getByText('Groups')).toBeInTheDocument()
     expect(screen.getByText('Last Accessed')).toBeInTheDocument()
-    expect(screen.getByText('Created')).toBeInTheDocument()
+  })
+
+  it('can show the Groups column and persists that choice between renders', async () => {
+    const user = userEvent.setup()
+    const { unmount } = render(<PeoplePage programs={programs} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Admin User')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole('columnheader', { name: 'Groups' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Choose columns' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Choose people table columns' })
+    await user.click(within(dialog).getByRole('checkbox', { name: 'Groups' }))
+    await user.click(within(dialog).getByRole('button', { name: 'Done' }))
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Choose people table columns' })).not.toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('columnheader', { name: 'Groups' })).toBeInTheDocument()
+    const chip = screen.getByText('Lab A2').closest('.MuiChip-root')
+    expect(chip).toBeInTheDocument()
+
+    unmount()
+    render(<PeoplePage programs={programs} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Admin User')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('columnheader', { name: 'Groups' })).toBeInTheDocument()
   })
 
   it('opens bulk role dialog and calls API', async () => {

--- a/frontend/tests/useTableColumnPreferences.test.ts
+++ b/frontend/tests/useTableColumnPreferences.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useTableColumnPreferences } from '../src/useTableColumnPreferences'
+
+type TestColumn = 'name' | 'email' | 'role'
+
+const allColumns = ['name', 'email', 'role'] as const satisfies readonly TestColumn[]
+const defaultVisibleColumns = ['name', 'role'] as const satisfies readonly TestColumn[]
+
+function renderPreferencesHook(tableKey = 'people') {
+  return renderHook(() =>
+    useTableColumnPreferences<TestColumn>({
+      tableKey,
+      allColumns,
+      defaultVisibleColumns,
+    }),
+  )
+}
+
+function storageKeyFor(userId: number | string) {
+  return `hrivpref:table-columns:people:user:${userId}`
+}
+
+describe('useTableColumnPreferences', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the default visibility when no stored preferences exist', () => {
+    localStorage.setItem('hriv_user', JSON.stringify({ id: 1 }))
+
+    const { result } = renderPreferencesHook()
+
+    expect(result.current.visibleColumns).toEqual({
+      name: true,
+      email: false,
+      role: true,
+    })
+    expect(result.current.isColumnVisible('name')).toBe(true)
+    expect(result.current.isColumnVisible('email')).toBe(false)
+  })
+
+  it('loads stored preferences from localStorage on mount', () => {
+    const storageKey = storageKeyFor(1)
+    localStorage.setItem('hriv_user', JSON.stringify({ id: 1 }))
+    localStorage.setItem(storageKey, JSON.stringify({
+      name: false,
+      email: true,
+      role: false,
+    }))
+
+    const { result } = renderPreferencesHook()
+
+    expect(result.current.visibleColumns).toEqual({
+      name: false,
+      email: true,
+      role: false,
+    })
+  })
+
+  it('setColumnVisible updates state and persists to localStorage', () => {
+    const storageKey = storageKeyFor(1)
+    localStorage.setItem('hriv_user', JSON.stringify({ id: 1 }))
+
+    const { result } = renderPreferencesHook()
+
+    act(() => {
+      result.current.setColumnVisible('email', true)
+    })
+
+    expect(result.current.visibleColumns.email).toBe(true)
+    expect(JSON.parse(localStorage.getItem(storageKey) ?? '{}')).toMatchObject({
+      name: true,
+      email: true,
+      role: true,
+    })
+  })
+
+  it('toggleColumn flips a column visibility value', () => {
+    localStorage.setItem('hriv_user', JSON.stringify({ id: 1 }))
+
+    const { result } = renderPreferencesHook()
+
+    act(() => {
+      result.current.toggleColumn('role')
+    })
+
+    expect(result.current.visibleColumns.role).toBe(false)
+  })
+
+  it('isColumnVisible returns the current boolean visibility state', () => {
+    localStorage.setItem('hriv_user', JSON.stringify({ id: 1 }))
+
+    const { result } = renderPreferencesHook()
+
+    expect(result.current.isColumnVisible('name')).toBe(true)
+    expect(result.current.isColumnVisible('email')).toBe(false)
+
+    act(() => {
+      result.current.toggleColumn('email')
+    })
+
+    expect(result.current.isColumnVisible('email')).toBe(true)
+  })
+
+  it('stores preferences in user-scoped keys so different users stay isolated', () => {
+    localStorage.setItem('hriv_user', JSON.stringify({ id: 1 }))
+    const firstUser = renderPreferencesHook()
+
+    act(() => {
+      firstUser.result.current.setColumnVisible('name', false)
+    })
+    firstUser.unmount()
+
+    localStorage.setItem('hriv_user', JSON.stringify({ id: 2 }))
+    const secondUser = renderPreferencesHook()
+
+    expect(secondUser.result.current.visibleColumns).toEqual({
+      name: true,
+      email: false,
+      role: true,
+    })
+    expect(JSON.parse(localStorage.getItem(storageKeyFor(1)) ?? '{}')).toMatchObject({
+      name: false,
+      email: false,
+      role: true,
+    })
+    expect(JSON.parse(localStorage.getItem(storageKeyFor(2)) ?? '{}')).toMatchObject({
+      name: true,
+      email: false,
+      role: true,
+    })
+  })
+
+  it('falls back to default visibility when stored preference JSON is corrupted', () => {
+    localStorage.setItem('hriv_user', JSON.stringify({ id: 1 }))
+    localStorage.setItem(storageKeyFor(1), '{not-json')
+
+    const { result } = renderPreferencesHook()
+
+    expect(result.current.visibleColumns).toEqual({
+      name: true,
+      email: false,
+      role: true,
+    })
+  })
+
+  it('gracefully falls back to in-memory state when localStorage is unavailable', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('localStorage unavailable')
+    })
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('localStorage unavailable')
+    })
+
+    const { result } = renderPreferencesHook()
+
+    expect(result.current.visibleColumns).toEqual({
+      name: true,
+      email: false,
+      role: true,
+    })
+
+    act(() => {
+      result.current.toggleColumn('email')
+    })
+
+    expect(result.current.visibleColumns.email).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- replace the Manage and People table filter icon buttons with MUI toggle button controls
- add per-table column chooser dialogs with the requested default visible columns and non-hideable actions columns
- persist column visibility preferences per user across logout/login and document the new manual test flow

## Accessibility
- label each toggle control per the MUI toggle button ARIA guidance and expose pressed state through the component semantics

## Testing
- nix-shell --run "cd frontend && npm test -- tests/components/ManagePage.test.tsx tests/components/PeoplePage.test.tsx && npm run build"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bcit-tlu/hriv/pull/661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->